### PR TITLE
DBAAS-753: when sync Inventory instances status, sync with AWS and ignore those don't exist in AWS

### DIFF
--- a/controllers/rds/test/dbinstance_mock.go
+++ b/controllers/rds/test/dbinstance_mock.go
@@ -28,20 +28,26 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 )
 
-var dbInstances = []*rds.DescribeDBInstancesOutput{
+var inventoryTestDBInstances = []*rds.DescribeDBInstancesOutput{
 	{
 		DBInstances: []types.DBInstance{
 			{
 				DBInstanceIdentifier: pointer.String("mock-db-instance-1"),
 				DBInstanceStatus:     pointer.String("available"),
+				Engine:               pointer.String("postgres"),
+				DBInstanceArn:        pointer.String("mock-db-instance-1"),
 			},
 			{
 				DBInstanceIdentifier: pointer.String("mock-db-instance-2"),
 				DBInstanceStatus:     pointer.String("available"),
+				Engine:               pointer.String("postgres"),
+				DBInstanceArn:        pointer.String("mock-db-instance-2"),
 			},
 			{
 				DBInstanceIdentifier: pointer.String("mock-db-instance-3"),
 				DBInstanceStatus:     pointer.String("available"),
+				Engine:               pointer.String("postgres"),
+				DBInstanceArn:        pointer.String("mock-db-instance-3"),
 			},
 		},
 	},
@@ -50,10 +56,14 @@ var dbInstances = []*rds.DescribeDBInstancesOutput{
 			{
 				DBInstanceIdentifier: pointer.String("mock-db-instance-4"),
 				DBInstanceStatus:     pointer.String("available"),
+				Engine:               pointer.String("postgres"),
+				DBInstanceArn:        pointer.String("mock-db-instance-4"),
 			},
 			{
 				DBInstanceIdentifier: pointer.String("mock-db-instance-5"),
 				DBInstanceStatus:     pointer.String("deleting"),
+				Engine:               pointer.String("mysql"),
+				DBInstanceArn:        pointer.String("mock-db-instance-5"),
 			},
 		},
 	},
@@ -62,20 +72,34 @@ var dbInstances = []*rds.DescribeDBInstancesOutput{
 			{
 				DBInstanceIdentifier: pointer.String("mock-adopted-db-instance-3"),
 				DBInstanceStatus:     pointer.String("available"),
+				Engine:               pointer.String("mariadb"),
 				DBName:               pointer.String("test-dbname"),
 				MasterUsername:       pointer.String("test-username"),
+				DBInstanceArn:        pointer.String("mock-adopted-db-instance-3"),
 			},
 			{
 				DBInstanceIdentifier: pointer.String("mock-adopted-db-instance-4"),
 				DBInstanceStatus:     pointer.String("deleting"),
+				Engine:               pointer.String("postgres"),
 				DBName:               pointer.String("test-dbname"),
 				MasterUsername:       pointer.String("test-username"),
+				DBInstanceArn:        pointer.String("mock-adopted-db-instance-4"),
 			},
 			{
 				DBInstanceIdentifier: pointer.String("mock-adopted-db-instance-5"),
 				DBInstanceStatus:     pointer.String("creating"),
+				Engine:               pointer.String("mysql"),
 				DBName:               pointer.String("test-dbname"),
 				MasterUsername:       pointer.String("test-username"),
+				DBInstanceArn:        pointer.String("mock-adopted-db-instance-5"),
+			},
+			{
+				DBInstanceIdentifier: pointer.String("mock-adopted-db-instance-15"),
+				DBInstanceStatus:     pointer.String("available"),
+				Engine:               pointer.String("mysql"),
+				DBName:               pointer.String("test-dbname"),
+				MasterUsername:       pointer.String("test-username"),
+				DBInstanceArn:        pointer.String("mock-adopted-db-instance-15-0"),
 			},
 		},
 	},
@@ -84,10 +108,14 @@ var dbInstances = []*rds.DescribeDBInstancesOutput{
 			{
 				DBInstanceIdentifier: pointer.String("mock-db-cluster-1"),
 				DBInstanceStatus:     pointer.String("available"),
+				Engine:               pointer.String("mysql"),
+				DBInstanceArn:        pointer.String("mock-db-cluster-1"),
 			},
 			{
 				DBInstanceIdentifier: pointer.String("mock-db-cluster-2"),
 				DBInstanceStatus:     pointer.String("available"),
+				Engine:               pointer.String("postgres"),
+				DBInstanceArn:        pointer.String("mock-db-cluster-2"),
 			},
 		},
 	},
@@ -97,36 +125,68 @@ var dbInstances = []*rds.DescribeDBInstancesOutput{
 				DBInstanceIdentifier: pointer.String("mock-db-aurora-1"),
 				DBInstanceStatus:     pointer.String("available"),
 				Engine:               pointer.String("aurora"),
+				DBInstanceArn:        pointer.String("mock-db-aurora-1"),
 			},
 			{
 				DBInstanceIdentifier: pointer.String("mock-db-aurora-2"),
 				DBInstanceStatus:     pointer.String("available"),
 				Engine:               pointer.String("aurora-mysql"),
+				DBInstanceArn:        pointer.String("mock-db-aurora-2"),
 			},
 			{
 				DBInstanceIdentifier: pointer.String("mock-db-aurora-3"),
 				DBInstanceStatus:     pointer.String("available"),
 				Engine:               pointer.String("aurora-postgresql"),
+				DBInstanceArn:        pointer.String("mock-db-aurora-3"),
 			},
 			{
 				DBInstanceIdentifier: pointer.String("mock-db-custom-1"),
 				DBInstanceStatus:     pointer.String("available"),
 				Engine:               pointer.String("custom-oracle-ee"),
+				DBInstanceArn:        pointer.String("mock-db-custom-1"),
 			},
 			{
 				DBInstanceIdentifier: pointer.String("mock-db-custom-2"),
 				DBInstanceStatus:     pointer.String("available"),
 				Engine:               pointer.String("custom-sqlserver-ee"),
+				DBInstanceArn:        pointer.String("mock-db-custom-2"),
 			},
 			{
 				DBInstanceIdentifier: pointer.String("mock-db-custom-3"),
 				DBInstanceStatus:     pointer.String("available"),
 				Engine:               pointer.String("custom-sqlserver-se"),
+				DBInstanceArn:        pointer.String("mock-db-custom-3"),
 			},
 			{
 				DBInstanceIdentifier: pointer.String("mock-db-custom-4"),
 				DBInstanceStatus:     pointer.String("available"),
 				Engine:               pointer.String("custom-sqlserver-web"),
+				DBInstanceArn:        pointer.String("mock-db-custom-4"),
+			},
+		},
+	},
+}
+
+var connectionTestDBInstances = []*rds.DescribeDBInstancesOutput{
+	{
+		DBInstances: []types.DBInstance{
+			{
+				DBInstanceIdentifier: pointer.String("instance-id-connection-controller"),
+				DBInstanceStatus:     pointer.String("available"),
+				Engine:               pointer.String("postgres"),
+				DBInstanceArn:        pointer.String("instance-id-connection-controller"),
+			},
+			{
+				DBInstanceIdentifier: pointer.String("instance-id-oracle-connection-controller"),
+				DBInstanceStatus:     pointer.String("available"),
+				Engine:               pointer.String("oracle-se2"),
+				DBInstanceArn:        pointer.String("instance-id-oracle-connection-controller"),
+			},
+			{
+				DBInstanceIdentifier: pointer.String("instance-id-sqlserver-connection-controller"),
+				DBInstanceStatus:     pointer.String("available"),
+				Engine:               pointer.String("sqlserver-ex"),
+				DBInstanceArn:        pointer.String("instance-id-sqlserver-connection-controller"),
 			},
 		},
 	},
@@ -141,6 +201,8 @@ func NewMockDescribeDBInstancesPaginator(accessKey, secretKey, region string) co
 	counter := 0
 	if strings.HasSuffix(accessKey, "INVENTORYCONTROLLER") {
 		counter = 3
+	} else if strings.HasSuffix(accessKey, "CONNECTIONCONTROLLER") {
+		counter = 1
 	}
 	return &mockDescribeDBInstancesPaginator{accessKey: accessKey, secretKey: secretKey, region: region, counter: counter}
 }
@@ -152,7 +214,11 @@ func (m *mockDescribeDBInstancesPaginator) HasMorePages() bool {
 func (m *mockDescribeDBInstancesPaginator) NextPage(ctx context.Context, f ...func(option *rds.Options)) (*rds.DescribeDBInstancesOutput, error) {
 	if m.counter > 0 {
 		m.counter--
-		return dbInstances[m.counter], nil
+		if strings.HasSuffix(m.accessKey, "INVENTORYCONTROLLER") {
+			return inventoryTestDBInstances[m.counter], nil
+		} else if strings.HasSuffix(m.accessKey, "CONNECTIONCONTROLLER") {
+			return connectionTestDBInstances[m.counter], nil
+		}
 	}
 	return nil, nil
 }

--- a/controllers/rds/test/dbinstance_mock.go
+++ b/controllers/rds/test/dbinstance_mock.go
@@ -192,6 +192,12 @@ var connectionTestDBInstances = []*rds.DescribeDBInstancesOutput{
 	},
 }
 
+var (
+	InventoryControllerTestAccessKeySuffix  = "INVENTORYCONTROLLER"
+	InstanceControllerTestAccessKeySuffix   = "INSTANCECONTROLLER"
+	ConnectionControllerTestAccessKeySuffix = "CONNECTIONCONTROLLER"
+)
+
 type mockDescribeDBInstancesPaginator struct {
 	accessKey, secretKey, region string
 	counter                      int
@@ -199,9 +205,9 @@ type mockDescribeDBInstancesPaginator struct {
 
 func NewMockDescribeDBInstancesPaginator(accessKey, secretKey, region string) controllersrds.DescribeDBInstancesPaginatorAPI {
 	counter := 0
-	if strings.HasSuffix(accessKey, "INVENTORYCONTROLLER") {
+	if strings.HasSuffix(accessKey, InventoryControllerTestAccessKeySuffix) {
 		counter = 3
-	} else if strings.HasSuffix(accessKey, "CONNECTIONCONTROLLER") {
+	} else if strings.HasSuffix(accessKey, ConnectionControllerTestAccessKeySuffix) {
 		counter = 1
 	}
 	return &mockDescribeDBInstancesPaginator{accessKey: accessKey, secretKey: secretKey, region: region, counter: counter}
@@ -214,9 +220,9 @@ func (m *mockDescribeDBInstancesPaginator) HasMorePages() bool {
 func (m *mockDescribeDBInstancesPaginator) NextPage(ctx context.Context, f ...func(option *rds.Options)) (*rds.DescribeDBInstancesOutput, error) {
 	if m.counter > 0 {
 		m.counter--
-		if strings.HasSuffix(m.accessKey, "INVENTORYCONTROLLER") {
+		if strings.HasSuffix(m.accessKey, InventoryControllerTestAccessKeySuffix) {
 			return inventoryTestDBInstances[m.counter], nil
-		} else if strings.HasSuffix(m.accessKey, "CONNECTIONCONTROLLER") {
+		} else if strings.HasSuffix(m.accessKey, ConnectionControllerTestAccessKeySuffix) {
 			return connectionTestDBInstances[m.counter], nil
 		}
 	}

--- a/controllers/rdsconnection_controller.go
+++ b/controllers/rdsconnection_controller.go
@@ -164,7 +164,7 @@ func (r *RDSConnectionReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			returnError(e, connectionStatusReasonBackendError, connectionStatusMessageGetInstanceError)
 			return true
 		}
-		if *dbInstance.Status.DBInstanceStatus != "available" {
+		if dbInstance.Status.DBInstanceStatus == nil || *dbInstance.Status.DBInstanceStatus != "available" {
 			e := fmt.Errorf("instance %s not ready", connection.Spec.InstanceID)
 			logger.Error(e, "DB Instance not ready")
 			returnError(e, connectionStatusReasonUnreachable, connectionStatusMessageInstanceNotReady)

--- a/controllers/rdsconnection_controller_test.go
+++ b/controllers/rdsconnection_controller_test.go
@@ -35,66 +35,141 @@ import (
 )
 
 var _ = Describe("RDSConnectionController", func() {
-	Context("when Connection is created", func() {
-		connectionName := "rds-connection-connection-controller"
-		inventoryName := "rds-inventory-connection-controller"
+	Context("when DB instances are created", func() {
 		instanceID := "instance-id-connection-controller"
 
-		connection := &rdsdbaasv1alpha1.RDSConnection{
+		dbInstance := &rdsv1alpha1.DBInstance{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      connectionName,
+				Name:      "db-instance-connection-controller",
 				Namespace: testNamespace,
 			},
-			Spec: dbaasv1alpha1.DBaaSConnectionSpec{
-				InventoryRef: dbaasv1alpha1.NamespacedName{
-					Name:      inventoryName,
-					Namespace: testNamespace,
-				},
-				InstanceID: instanceID,
+			Spec: rdsv1alpha1.DBInstanceSpec{
+				Engine:               pointer.String("postgres"),
+				DBInstanceIdentifier: pointer.String(instanceID),
+				DBInstanceClass:      pointer.String("db.t3.micro"),
 			},
 		}
-		BeforeEach(assertResourceCreation(connection))
-		AfterEach(assertResourceDeletion(connection))
-
-		Context("when Inventory is not created", func() {
-			It("should make Connection in error status", func() {
-				conn := &rdsdbaasv1alpha1.RDSConnection{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      connectionName,
-						Namespace: testNamespace,
-					},
+		BeforeEach(assertResourceCreation(dbInstance))
+		AfterEach(assertResourceDeletion(dbInstance))
+		BeforeEach(func() {
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dbInstance), dbInstance); err != nil {
+					return false
 				}
-				Eventually(func() bool {
-					if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(conn), conn); err != nil {
-						return false
-					}
-					condition := apimeta.FindStatusCondition(conn.Status.Conditions, "ReadyForBinding")
-					if condition == nil || condition.Status != metav1.ConditionFalse || condition.Reason != "NotFound" {
-						return false
-					}
-					return true
-				}, timeout).Should(BeTrue())
-			})
+				arn := ackv1alpha1.AWSResourceName(instanceID)
+				ownerAccountID := ackv1alpha1.AWSAccountID("testOwnerId")
+				region := ackv1alpha1.AWSRegion("us-east-1")
+				dbInstance.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{
+					ARN:            &arn,
+					OwnerAccountID: &ownerAccountID,
+					Region:         &region,
+				}
+				err := k8sClient.Status().Update(ctx, dbInstance)
+				return err == nil
+			}, timeout).Should(BeTrue())
 		})
 
-		Context("when Inventory is created", func() {
-			credentialName := "credentials-ref-connection-controller"
+		instanceIDOracle := "instance-id-oracle-connection-controller"
+		dbInstanceOracle := &rdsv1alpha1.DBInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "db-instance-oracle-connection-controller",
+				Namespace: testNamespace,
+			},
+			Spec: rdsv1alpha1.DBInstanceSpec{
+				Engine:               pointer.String("oracle-se2"),
+				DBInstanceIdentifier: pointer.String(instanceIDOracle),
+				DBInstanceClass:      pointer.String("db.t3.micro"),
+				MasterUserPassword: &ackv1alpha1.SecretKeyReference{
+					SecretReference: v1.SecretReference{
+						Name:      "secret-jdbc-url-connection-controller",
+						Namespace: testNamespace,
+					},
+					Key: "password",
+				},
+				MasterUsername: pointer.String("user-oracle-connection-controller"),
+			},
+		}
+		BeforeEach(assertResourceCreation(dbInstanceOracle))
+		AfterEach(assertResourceDeletion(dbInstanceOracle))
+		BeforeEach(func() {
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dbInstanceOracle), dbInstanceOracle); err != nil {
+					return false
+				}
+				arn := ackv1alpha1.AWSResourceName(instanceIDOracle)
+				ownerAccountID := ackv1alpha1.AWSAccountID("testOwnerId")
+				region := ackv1alpha1.AWSRegion("us-east-1")
+				dbInstanceOracle.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{
+					ARN:            &arn,
+					OwnerAccountID: &ownerAccountID,
+					Region:         &region,
+				}
+				err := k8sClient.Status().Update(ctx, dbInstanceOracle)
+				return err == nil
+			}, timeout).Should(BeTrue())
+		})
 
-			inventory := &rdsdbaasv1alpha1.RDSInventory{
+		instanceIDSqlServer := "instance-id-sqlserver-connection-controller"
+		dbInstanceSqlServer := &rdsv1alpha1.DBInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "db-instance-sqlserver-connection-controller",
+				Namespace: testNamespace,
+			},
+			Spec: rdsv1alpha1.DBInstanceSpec{
+				Engine:               pointer.String("sqlserver-ex"),
+				DBInstanceIdentifier: pointer.String(instanceIDSqlServer),
+				DBInstanceClass:      pointer.String("db.t3.micro"),
+				MasterUserPassword: &ackv1alpha1.SecretKeyReference{
+					SecretReference: v1.SecretReference{
+						Name:      "secret-jdbc-url-connection-controller",
+						Namespace: testNamespace,
+					},
+					Key: "password",
+				},
+				MasterUsername: pointer.String("user-sqlserver-connection-controller"),
+			},
+		}
+		BeforeEach(assertResourceCreation(dbInstanceSqlServer))
+		AfterEach(assertResourceDeletion(dbInstanceSqlServer))
+		BeforeEach(func() {
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dbInstanceSqlServer), dbInstanceSqlServer); err != nil {
+					return false
+				}
+				arn := ackv1alpha1.AWSResourceName(instanceIDSqlServer)
+				ownerAccountID := ackv1alpha1.AWSAccountID("testOwnerId")
+				region := ackv1alpha1.AWSRegion("us-east-1")
+				dbInstanceSqlServer.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{
+					ARN:            &arn,
+					OwnerAccountID: &ownerAccountID,
+					Region:         &region,
+				}
+				err := k8sClient.Status().Update(ctx, dbInstanceSqlServer)
+				return err == nil
+			}, timeout).Should(BeTrue())
+		})
+
+		Context("when Connection is created", func() {
+			connectionName := "rds-connection-connection-controller"
+			inventoryName := "rds-inventory-connection-controller"
+
+			connection := &rdsdbaasv1alpha1.RDSConnection{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      inventoryName,
+					Name:      connectionName,
 					Namespace: testNamespace,
 				},
-				Spec: dbaasv1alpha1.DBaaSInventorySpec{
-					CredentialsRef: &dbaasv1alpha1.LocalObjectReference{
-						Name: credentialName,
+				Spec: dbaasv1alpha1.DBaaSConnectionSpec{
+					InventoryRef: dbaasv1alpha1.NamespacedName{
+						Name:      inventoryName,
+						Namespace: testNamespace,
 					},
+					InstanceID: instanceID,
 				},
 			}
-			BeforeEach(assertResourceCreation(inventory))
-			AfterEach(assertResourceDeletion(inventory))
+			BeforeEach(assertResourceCreation(connection))
+			AfterEach(assertResourceDeletion(connection))
 
-			Context("when Inventory is not ready", func() {
+			Context("when Inventory is not created", func() {
 				It("should make Connection in error status", func() {
 					conn := &rdsdbaasv1alpha1.RDSConnection{
 						ObjectMeta: metav1.ObjectMeta{
@@ -107,7 +182,7 @@ var _ = Describe("RDSConnectionController", func() {
 							return false
 						}
 						condition := apimeta.FindStatusCondition(conn.Status.Conditions, "ReadyForBinding")
-						if condition == nil || condition.Status != metav1.ConditionFalse || condition.Reason != "Unreachable" {
+						if condition == nil || condition.Status != metav1.ConditionFalse || condition.Reason != "NotFound" {
 							return false
 						}
 						return true
@@ -115,26 +190,24 @@ var _ = Describe("RDSConnectionController", func() {
 				})
 			})
 
-			Context("when Inventory is ready", func() {
-				accessKey := "AKIAIOSFODNN7EXAMPLECONNECTIONCONTROLLER"
-				secretKey := "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-				region := "us-east-1"
+			Context("when Inventory is created", func() {
+				credentialName := "credentials-ref-connection-controller"
 
-				credential := &v1.Secret{
+				inventory := &rdsdbaasv1alpha1.RDSInventory{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      credentialName,
+						Name:      inventoryName,
 						Namespace: testNamespace,
 					},
-					Data: map[string][]byte{
-						"AWS_ACCESS_KEY_ID":     []byte(accessKey),
-						"AWS_SECRET_ACCESS_KEY": []byte(secretKey), //#nosec G101
-						"AWS_REGION":            []byte(region),
+					Spec: dbaasv1alpha1.DBaaSInventorySpec{
+						CredentialsRef: &dbaasv1alpha1.LocalObjectReference{
+							Name: credentialName,
+						},
 					},
 				}
-				BeforeEach(assertResourceCreation(credential))
-				AfterEach(assertResourceDeletion(credential))
+				BeforeEach(assertResourceCreation(inventory))
+				AfterEach(assertResourceDeletion(inventory))
 
-				Context("when Instance is not found", func() {
+				Context("when Inventory is not ready", func() {
 					It("should make Connection in error status", func() {
 						conn := &rdsdbaasv1alpha1.RDSConnection{
 							ObjectMeta: metav1.ObjectMeta{
@@ -147,7 +220,7 @@ var _ = Describe("RDSConnectionController", func() {
 								return false
 							}
 							condition := apimeta.FindStatusCondition(conn.Status.Conditions, "ReadyForBinding")
-							if condition == nil || condition.Status != metav1.ConditionFalse || condition.Reason != "NotFound" {
+							if condition == nil || condition.Status != metav1.ConditionFalse || condition.Reason != "Unreachable" {
 								return false
 							}
 							return true
@@ -155,22 +228,43 @@ var _ = Describe("RDSConnectionController", func() {
 					})
 				})
 
-				Context("when Inventory and Instance are created", func() {
-					dbInstance := &rdsv1alpha1.DBInstance{
+				Context("when Inventory is ready", func() {
+					accessKey := "AKIAIOSFODNN7EXAMPLECONNECTIONCONTROLLER"
+					secretKey := "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+					region := "us-east-1"
+
+					credential := &v1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "db-instance-connection-controller",
+							Name:      credentialName,
 							Namespace: testNamespace,
 						},
-						Spec: rdsv1alpha1.DBInstanceSpec{
-							Engine:               pointer.String("postgres"),
-							DBInstanceIdentifier: pointer.String(instanceID),
-							DBInstanceClass:      pointer.String("db.t3.micro"),
+						Data: map[string][]byte{
+							"AWS_ACCESS_KEY_ID":     []byte(accessKey),
+							"AWS_SECRET_ACCESS_KEY": []byte(secretKey), //#nosec G101
+							"AWS_REGION":            []byte(region),
 						},
 					}
-					BeforeEach(assertResourceCreation(dbInstance))
-					AfterEach(assertResourceDeletion(dbInstance))
+					BeforeEach(assertResourceCreation(credential))
+					AfterEach(assertResourceDeletion(credential))
 
-					Context("when Instance is not ready", func() {
+					Context("when Instance is not found", func() {
+						BeforeEach(func() {
+							conn := &rdsdbaasv1alpha1.RDSConnection{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      connectionName,
+									Namespace: testNamespace,
+								},
+							}
+							Eventually(func() bool {
+								if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(conn), conn); err != nil {
+									return false
+								}
+								conn.Spec.InstanceID = "instance-id-connection-controller-not-exist"
+								err := k8sClient.Update(ctx, conn)
+								return err == nil
+							}, timeout).Should(BeTrue())
+						})
+
 						It("should make Connection in error status", func() {
 							conn := &rdsdbaasv1alpha1.RDSConnection{
 								ObjectMeta: metav1.ObjectMeta{
@@ -183,7 +277,7 @@ var _ = Describe("RDSConnectionController", func() {
 									return false
 								}
 								condition := apimeta.FindStatusCondition(conn.Status.Conditions, "ReadyForBinding")
-								if condition == nil || condition.Status != metav1.ConditionFalse || condition.Reason != "Unreachable" {
+								if condition == nil || condition.Status != metav1.ConditionFalse || condition.Reason != "NotFound" {
 									return false
 								}
 								return true
@@ -191,19 +285,8 @@ var _ = Describe("RDSConnectionController", func() {
 						})
 					})
 
-					Context("when Inventory and Instance are ready", func() {
-						BeforeEach(func() {
-							Eventually(func() bool {
-								if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dbInstance), dbInstance); err != nil {
-									return false
-								}
-								dbInstance.Status.DBInstanceStatus = pointer.String("available")
-								err := k8sClient.Status().Update(ctx, dbInstance)
-								return err == nil
-							}, timeout).Should(BeTrue())
-						})
-
-						Context("when the Instance user password is not set", func() {
+					Context("when Inventory and Instance are created", func() {
+						Context("when Instance is not ready", func() {
 							It("should make Connection in error status", func() {
 								conn := &rdsdbaasv1alpha1.RDSConnection{
 									ObjectMeta: metav1.ObjectMeta{
@@ -216,7 +299,7 @@ var _ = Describe("RDSConnectionController", func() {
 										return false
 									}
 									condition := apimeta.FindStatusCondition(conn.Status.Conditions, "ReadyForBinding")
-									if condition == nil || condition.Status != metav1.ConditionFalse || condition.Reason != "InputError" {
+									if condition == nil || condition.Status != metav1.ConditionFalse || condition.Reason != "Unreachable" {
 										return false
 									}
 									return true
@@ -224,25 +307,19 @@ var _ = Describe("RDSConnectionController", func() {
 							})
 						})
 
-						Context("when the Instance user password is set", func() {
+						Context("when Inventory and Instance are ready", func() {
 							BeforeEach(func() {
 								Eventually(func() bool {
 									if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dbInstance), dbInstance); err != nil {
 										return false
 									}
-									dbInstance.Spec.MasterUserPassword = &ackv1alpha1.SecretKeyReference{
-										SecretReference: v1.SecretReference{
-											Name:      "secret-connection-controller",
-											Namespace: testNamespace,
-										},
-										Key: "password",
-									}
-									err := k8sClient.Update(ctx, dbInstance)
+									dbInstance.Status.DBInstanceStatus = pointer.String("available")
+									err := k8sClient.Status().Update(ctx, dbInstance)
 									return err == nil
 								}, timeout).Should(BeTrue())
 							})
 
-							Context("when the Instance user password Secret is not created", func() {
+							Context("when the Instance user password is not set", func() {
 								It("should make Connection in error status", func() {
 									conn := &rdsdbaasv1alpha1.RDSConnection{
 										ObjectMeta: metav1.ObjectMeta{
@@ -255,7 +332,7 @@ var _ = Describe("RDSConnectionController", func() {
 											return false
 										}
 										condition := apimeta.FindStatusCondition(conn.Status.Conditions, "ReadyForBinding")
-										if condition == nil || condition.Status != metav1.ConditionFalse || condition.Reason != "NotFound" {
+										if condition == nil || condition.Status != metav1.ConditionFalse || condition.Reason != "InputError" {
 											return false
 										}
 										return true
@@ -263,17 +340,25 @@ var _ = Describe("RDSConnectionController", func() {
 								})
 							})
 
-							Context("when the Instance user password Secret is created", func() {
-								passwordSecret := &v1.Secret{
-									ObjectMeta: metav1.ObjectMeta{
-										Name:      "secret-connection-controller",
-										Namespace: testNamespace,
-									},
-								}
-								BeforeEach(assertResourceCreation(passwordSecret))
-								AfterEach(assertResourceDeletion(passwordSecret))
+							Context("when the Instance user password is set", func() {
+								BeforeEach(func() {
+									Eventually(func() bool {
+										if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dbInstance), dbInstance); err != nil {
+											return false
+										}
+										dbInstance.Spec.MasterUserPassword = &ackv1alpha1.SecretKeyReference{
+											SecretReference: v1.SecretReference{
+												Name:      "secret-connection-controller",
+												Namespace: testNamespace,
+											},
+											Key: "password",
+										}
+										err := k8sClient.Update(ctx, dbInstance)
+										return err == nil
+									}, timeout).Should(BeTrue())
+								})
 
-								Context("when the Instance user password Secret is not valid", func() {
+								Context("when the Instance user password Secret is not created", func() {
 									It("should make Connection in error status", func() {
 										conn := &rdsdbaasv1alpha1.RDSConnection{
 											ObjectMeta: metav1.ObjectMeta{
@@ -286,7 +371,7 @@ var _ = Describe("RDSConnectionController", func() {
 												return false
 											}
 											condition := apimeta.FindStatusCondition(conn.Status.Conditions, "ReadyForBinding")
-											if condition == nil || condition.Status != metav1.ConditionFalse || condition.Reason != "InputError" {
+											if condition == nil || condition.Status != metav1.ConditionFalse || condition.Reason != "NotFound" {
 												return false
 											}
 											return true
@@ -294,21 +379,17 @@ var _ = Describe("RDSConnectionController", func() {
 									})
 								})
 
-								Context("when the Instance user password Secret is valid", func() {
-									BeforeEach(func() {
-										Eventually(func() bool {
-											if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(passwordSecret), passwordSecret); err != nil {
-												return false
-											}
-											passwordSecret.Data = map[string][]byte{
-												"password": []byte("testpassword"),
-											}
-											err := k8sClient.Update(ctx, passwordSecret)
-											return err == nil
-										}, timeout).Should(BeTrue())
-									})
+								Context("when the Instance user password Secret is created", func() {
+									passwordSecret := &v1.Secret{
+										ObjectMeta: metav1.ObjectMeta{
+											Name:      "secret-connection-controller",
+											Namespace: testNamespace,
+										},
+									}
+									BeforeEach(assertResourceCreation(passwordSecret))
+									AfterEach(assertResourceDeletion(passwordSecret))
 
-									Context("when the Instance user name is not set", func() {
+									Context("when the Instance user password Secret is not valid", func() {
 										It("should make Connection in error status", func() {
 											conn := &rdsdbaasv1alpha1.RDSConnection{
 												ObjectMeta: metav1.ObjectMeta{
@@ -329,19 +410,21 @@ var _ = Describe("RDSConnectionController", func() {
 										})
 									})
 
-									Context("when the Instance user name is set", func() {
+									Context("when the Instance user password Secret is valid", func() {
 										BeforeEach(func() {
 											Eventually(func() bool {
-												if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dbInstance), dbInstance); err != nil {
+												if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(passwordSecret), passwordSecret); err != nil {
 													return false
 												}
-												dbInstance.Spec.MasterUsername = pointer.String("user-connection-controller")
-												err := k8sClient.Update(ctx, dbInstance)
+												passwordSecret.Data = map[string][]byte{
+													"password": []byte("testpassword"),
+												}
+												err := k8sClient.Update(ctx, passwordSecret)
 												return err == nil
 											}, timeout).Should(BeTrue())
 										})
 
-										Context("when the Instance endpoint is not available", func() {
+										Context("when the Instance user name is not set", func() {
 											It("should make Connection in error status", func() {
 												conn := &rdsdbaasv1alpha1.RDSConnection{
 													ObjectMeta: metav1.ObjectMeta{
@@ -354,7 +437,7 @@ var _ = Describe("RDSConnectionController", func() {
 														return false
 													}
 													condition := apimeta.FindStatusCondition(conn.Status.Conditions, "ReadyForBinding")
-													if condition == nil || condition.Status != metav1.ConditionFalse || condition.Reason != "Unreachable" {
+													if condition == nil || condition.Status != metav1.ConditionFalse || condition.Reason != "InputError" {
 														return false
 													}
 													return true
@@ -362,24 +445,20 @@ var _ = Describe("RDSConnectionController", func() {
 											})
 										})
 
-										Context("when the Instance endpoint is available", func() {
+										Context("when the Instance user name is set", func() {
 											BeforeEach(func() {
 												Eventually(func() bool {
 													if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dbInstance), dbInstance); err != nil {
 														return false
 													}
-													dbInstance.Status.Endpoint = &rdsv1alpha1.Endpoint{
-														Address: pointer.String("address-connection-controller"),
-														Port:    pointer.Int64(9000),
-													}
-													err := k8sClient.Status().Update(ctx, dbInstance)
+													dbInstance.Spec.MasterUsername = pointer.String("user-connection-controller")
+													err := k8sClient.Update(ctx, dbInstance)
 													return err == nil
 												}, timeout).Should(BeTrue())
 											})
 
-											Context("when the Instance connection info is complete", func() {
-												It("should create Secret and ConfigMap for binding", func() {
-													By("checking the status of the Connection")
+											Context("when the Instance endpoint is not available", func() {
+												It("should make Connection in error status", func() {
 													conn := &rdsdbaasv1alpha1.RDSConnection{
 														ObjectMeta: metav1.ObjectMeta{
 															Name:      connectionName,
@@ -391,72 +470,110 @@ var _ = Describe("RDSConnectionController", func() {
 															return false
 														}
 														condition := apimeta.FindStatusCondition(conn.Status.Conditions, "ReadyForBinding")
-														if condition == nil || condition.Status != metav1.ConditionTrue || condition.Reason != "Ready" {
+														if condition == nil || condition.Status != metav1.ConditionFalse || condition.Reason != "Unreachable" {
 															return false
 														}
-														Expect(conn.Status.CredentialsRef).ShouldNot(BeNil())
-														Expect(conn.Status.CredentialsRef.Name).Should(Equal(fmt.Sprintf("%s-credentials", conn.Name)))
-														Expect(conn.Status.ConnectionInfoRef).ShouldNot(BeNil())
-														Expect(conn.Status.ConnectionInfoRef.Name).Should(Equal(fmt.Sprintf("%s-configs", conn.Name)))
 														return true
 													}, timeout).Should(BeTrue())
+												})
+											})
 
-													By("checking the Secret of the Connection")
-													secret := &v1.Secret{
-														ObjectMeta: metav1.ObjectMeta{
-															Name:      conn.Status.CredentialsRef.Name,
-															Namespace: testNamespace,
-														},
-													}
-													err := k8sClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)
-													Expect(err).ShouldNot(HaveOccurred())
-													secretOwner := metav1.GetControllerOf(secret)
-													Expect(secretOwner).ShouldNot(BeNil())
-													Expect(secretOwner.Kind).Should(Equal("RDSConnection"))
-													Expect(secretOwner.Name).Should(Equal(conn.Name))
-													Expect(secretOwner.Controller).ShouldNot(BeNil())
-													Expect(*secretOwner.Controller).Should(BeTrue())
-													Expect(secretOwner.BlockOwnerDeletion).ShouldNot(BeNil())
-													Expect(*secretOwner.BlockOwnerDeletion).Should(BeTrue())
-													user, userOk := secret.Data["username"]
-													Expect(userOk).Should(BeTrue())
-													Expect(string(user)).Should(Equal("user-connection-controller"))
-													password, passwordOk := secret.Data["password"]
-													Expect(passwordOk).Should(BeTrue())
-													Expect(string(password)).Should(Equal("testpassword"))
+											Context("when the Instance endpoint is available", func() {
+												BeforeEach(func() {
+													Eventually(func() bool {
+														if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dbInstance), dbInstance); err != nil {
+															return false
+														}
+														dbInstance.Status.Endpoint = &rdsv1alpha1.Endpoint{
+															Address: pointer.String("address-connection-controller"),
+															Port:    pointer.Int64(9000),
+														}
+														err := k8sClient.Status().Update(ctx, dbInstance)
+														return err == nil
+													}, timeout).Should(BeTrue())
+												})
 
-													By("checking the ConfigMap of the Connection")
-													configmap := &v1.ConfigMap{
-														ObjectMeta: metav1.ObjectMeta{
-															Name:      conn.Status.ConnectionInfoRef.Name,
-															Namespace: testNamespace,
-														},
-													}
-													err = k8sClient.Get(ctx, client.ObjectKeyFromObject(configmap), configmap)
-													Expect(err).ShouldNot(HaveOccurred())
-													configmapOwner := metav1.GetControllerOf(configmap)
-													Expect(configmapOwner).ShouldNot(BeNil())
-													Expect(configmapOwner.Kind).Should(Equal("RDSConnection"))
-													Expect(configmapOwner.Name).Should(Equal(conn.Name))
-													Expect(configmapOwner.Controller).ShouldNot(BeNil())
-													Expect(*configmapOwner.Controller).Should(BeTrue())
-													Expect(configmapOwner.BlockOwnerDeletion).ShouldNot(BeNil())
-													Expect(*configmapOwner.BlockOwnerDeletion).Should(BeTrue())
-													t, typeOk := configmap.Data["type"]
-													Expect(typeOk).Should(BeTrue())
-													Expect(t).Should(Equal("postgresql"))
-													provider, providerOk := configmap.Data["provider"]
-													Expect(providerOk).Should(BeTrue())
-													Expect(provider).Should(Equal("Red Hat DBaaS / Amazon Relational Database Service (RDS)"))
-													host, hostOk := configmap.Data["host"]
-													Expect(hostOk).Should(BeTrue())
-													Expect(host).Should(Equal("address-connection-controller"))
-													port, portOk := configmap.Data["port"]
-													Expect(portOk).Should(BeTrue())
-													Expect(port).Should(Equal("9000"))
-													db, dbOk := configmap.Data["database"]
-													Expect(dbOk).Should(BeTrue())
-													Expect(db).Should(Equal("postgres"))
+												Context("when the Instance connection info is complete", func() {
+													It("should create Secret and ConfigMap for binding", func() {
+														By("checking the status of the Connection")
+														conn := &rdsdbaasv1alpha1.RDSConnection{
+															ObjectMeta: metav1.ObjectMeta{
+																Name:      connectionName,
+																Namespace: testNamespace,
+															},
+														}
+														Eventually(func() bool {
+															if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(conn), conn); err != nil {
+																return false
+															}
+															condition := apimeta.FindStatusCondition(conn.Status.Conditions, "ReadyForBinding")
+															if condition == nil || condition.Status != metav1.ConditionTrue || condition.Reason != "Ready" {
+																return false
+															}
+															Expect(conn.Status.CredentialsRef).ShouldNot(BeNil())
+															Expect(conn.Status.CredentialsRef.Name).Should(Equal(fmt.Sprintf("%s-credentials", conn.Name)))
+															Expect(conn.Status.ConnectionInfoRef).ShouldNot(BeNil())
+															Expect(conn.Status.ConnectionInfoRef.Name).Should(Equal(fmt.Sprintf("%s-configs", conn.Name)))
+															return true
+														}, timeout).Should(BeTrue())
+
+														By("checking the Secret of the Connection")
+														secret := &v1.Secret{
+															ObjectMeta: metav1.ObjectMeta{
+																Name:      conn.Status.CredentialsRef.Name,
+																Namespace: testNamespace,
+															},
+														}
+														err := k8sClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)
+														Expect(err).ShouldNot(HaveOccurred())
+														secretOwner := metav1.GetControllerOf(secret)
+														Expect(secretOwner).ShouldNot(BeNil())
+														Expect(secretOwner.Kind).Should(Equal("RDSConnection"))
+														Expect(secretOwner.Name).Should(Equal(conn.Name))
+														Expect(secretOwner.Controller).ShouldNot(BeNil())
+														Expect(*secretOwner.Controller).Should(BeTrue())
+														Expect(secretOwner.BlockOwnerDeletion).ShouldNot(BeNil())
+														Expect(*secretOwner.BlockOwnerDeletion).Should(BeTrue())
+														user, userOk := secret.Data["username"]
+														Expect(userOk).Should(BeTrue())
+														Expect(string(user)).Should(Equal("user-connection-controller"))
+														password, passwordOk := secret.Data["password"]
+														Expect(passwordOk).Should(BeTrue())
+														Expect(string(password)).Should(Equal("testpassword"))
+
+														By("checking the ConfigMap of the Connection")
+														configmap := &v1.ConfigMap{
+															ObjectMeta: metav1.ObjectMeta{
+																Name:      conn.Status.ConnectionInfoRef.Name,
+																Namespace: testNamespace,
+															},
+														}
+														err = k8sClient.Get(ctx, client.ObjectKeyFromObject(configmap), configmap)
+														Expect(err).ShouldNot(HaveOccurred())
+														configmapOwner := metav1.GetControllerOf(configmap)
+														Expect(configmapOwner).ShouldNot(BeNil())
+														Expect(configmapOwner.Kind).Should(Equal("RDSConnection"))
+														Expect(configmapOwner.Name).Should(Equal(conn.Name))
+														Expect(configmapOwner.Controller).ShouldNot(BeNil())
+														Expect(*configmapOwner.Controller).Should(BeTrue())
+														Expect(configmapOwner.BlockOwnerDeletion).ShouldNot(BeNil())
+														Expect(*configmapOwner.BlockOwnerDeletion).Should(BeTrue())
+														t, typeOk := configmap.Data["type"]
+														Expect(typeOk).Should(BeTrue())
+														Expect(t).Should(Equal("postgresql"))
+														provider, providerOk := configmap.Data["provider"]
+														Expect(providerOk).Should(BeTrue())
+														Expect(provider).Should(Equal("Red Hat DBaaS / Amazon Relational Database Service (RDS)"))
+														host, hostOk := configmap.Data["host"]
+														Expect(hostOk).Should(BeTrue())
+														Expect(host).Should(Equal("address-connection-controller"))
+														port, portOk := configmap.Data["port"]
+														Expect(portOk).Should(BeTrue())
+														Expect(port).Should(Equal("9000"))
+														db, dbOk := configmap.Data["database"]
+														Expect(dbOk).Should(BeTrue())
+														Expect(db).Should(Equal("postgres"))
+													})
 												})
 											})
 										})
@@ -468,270 +585,224 @@ var _ = Describe("RDSConnectionController", func() {
 				})
 			})
 		})
-	})
 
-	Context("when Inventory is created and ready", func() {
-		credentialName := "credentials-ref-jdbc-url-connection-controller"
-		accessKey := "AKIAIOSFODNN7EXAMPLECONNECTIONCONTROLLER"
-		secretKey := "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-		region := "us-east-1"
+		Context("when Inventory is created and ready", func() {
+			credentialName := "credentials-ref-jdbc-url-connection-controller"
+			accessKey := "AKIAIOSFODNN7EXAMPLECONNECTIONCONTROLLER"
+			secretKey := "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+			region := "us-east-1"
 
-		credential := &v1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      credentialName,
-				Namespace: testNamespace,
-			},
-			Data: map[string][]byte{
-				"AWS_ACCESS_KEY_ID":     []byte(accessKey),
-				"AWS_SECRET_ACCESS_KEY": []byte(secretKey), //#nosec G101
-				"AWS_REGION":            []byte(region),
-			},
-		}
-		BeforeEach(assertResourceCreation(credential))
-		AfterEach(assertResourceDeletion(credential))
-
-		inventoryName := "rds-inventory-jdbc-url-connection-controller"
-		inventory := &rdsdbaasv1alpha1.RDSInventory{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      inventoryName,
-				Namespace: testNamespace,
-			},
-			Spec: dbaasv1alpha1.DBaaSInventorySpec{
-				CredentialsRef: &dbaasv1alpha1.LocalObjectReference{
-					Name: credentialName,
-				},
-			},
-		}
-		BeforeEach(assertResourceCreation(inventory))
-		AfterEach(assertResourceDeletion(inventory))
-
-		passwordSecret := &v1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "secret-jdbc-url-connection-controller",
-				Namespace: testNamespace,
-			},
-			Data: map[string][]byte{
-				"password": []byte("testpassword"),
-			},
-		}
-		BeforeEach(assertResourceCreation(passwordSecret))
-		AfterEach(assertResourceDeletion(passwordSecret))
-
-		Context("when Connection for Oracle is created", func() {
-			instanceID := "instance-id-oracle-connection-controller"
-			dbInstance := &rdsv1alpha1.DBInstance{
+			credential := &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "db-instance-oracle-connection-controller",
+					Name:      credentialName,
 					Namespace: testNamespace,
 				},
-				Spec: rdsv1alpha1.DBInstanceSpec{
-					Engine:               pointer.String("oracle-se2"),
-					DBInstanceIdentifier: pointer.String(instanceID),
-					DBInstanceClass:      pointer.String("db.t3.micro"),
-					MasterUserPassword: &ackv1alpha1.SecretKeyReference{
-						SecretReference: v1.SecretReference{
-							Name:      "secret-jdbc-url-connection-controller",
-							Namespace: testNamespace,
-						},
-						Key: "password",
-					},
-					MasterUsername: pointer.String("user-oracle-connection-controller"),
+				Data: map[string][]byte{
+					"AWS_ACCESS_KEY_ID":     []byte(accessKey),
+					"AWS_SECRET_ACCESS_KEY": []byte(secretKey), //#nosec G101
+					"AWS_REGION":            []byte(region),
 				},
 			}
-			BeforeEach(assertResourceCreation(dbInstance))
-			AfterEach(assertResourceDeletion(dbInstance))
+			BeforeEach(assertResourceCreation(credential))
+			AfterEach(assertResourceDeletion(credential))
 
-			BeforeEach(func() {
-				Eventually(func() bool {
-					if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dbInstance), dbInstance); err != nil {
-						return false
-					}
-					dbInstance.Status.DBInstanceStatus = pointer.String("available")
-					dbInstance.Status.Endpoint = &rdsv1alpha1.Endpoint{
-						Address: pointer.String("address-oracle-connection-controller"),
-						Port:    pointer.Int64(9000),
-					}
-					err := k8sClient.Status().Update(ctx, dbInstance)
-					return err == nil
-				}, timeout).Should(BeTrue())
-			})
-
-			connectionName := "rds-connection-oracle-connection-controller"
-			connection := &rdsdbaasv1alpha1.RDSConnection{
+			inventoryName := "rds-inventory-jdbc-url-connection-controller"
+			inventory := &rdsdbaasv1alpha1.RDSInventory{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      connectionName,
+					Name:      inventoryName,
 					Namespace: testNamespace,
 				},
-				Spec: dbaasv1alpha1.DBaaSConnectionSpec{
-					InventoryRef: dbaasv1alpha1.NamespacedName{
-						Name:      inventoryName,
-						Namespace: testNamespace,
+				Spec: dbaasv1alpha1.DBaaSInventorySpec{
+					CredentialsRef: &dbaasv1alpha1.LocalObjectReference{
+						Name: credentialName,
 					},
-					InstanceID: instanceID,
 				},
 			}
-			BeforeEach(assertResourceCreation(connection))
-			AfterEach(assertResourceDeletion(connection))
+			BeforeEach(assertResourceCreation(inventory))
+			AfterEach(assertResourceDeletion(inventory))
 
-			It("should add jdbc-url to the ConfigMap for service binding", func() {
-				By("checking the status of the Connection")
-				conn := &rdsdbaasv1alpha1.RDSConnection{
+			passwordSecret := &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret-jdbc-url-connection-controller",
+					Namespace: testNamespace,
+				},
+				Data: map[string][]byte{
+					"password": []byte("testpassword"),
+				},
+			}
+			BeforeEach(assertResourceCreation(passwordSecret))
+			AfterEach(assertResourceDeletion(passwordSecret))
+
+			Context("when Connection for Oracle is created", func() {
+				BeforeEach(func() {
+					Eventually(func() bool {
+						if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dbInstanceOracle), dbInstanceOracle); err != nil {
+							return false
+						}
+						dbInstanceOracle.Status.DBInstanceStatus = pointer.String("available")
+						dbInstanceOracle.Status.Endpoint = &rdsv1alpha1.Endpoint{
+							Address: pointer.String("address-oracle-connection-controller"),
+							Port:    pointer.Int64(9000),
+						}
+						err := k8sClient.Status().Update(ctx, dbInstanceOracle)
+						return err == nil
+					}, timeout).Should(BeTrue())
+				})
+
+				connectionName := "rds-connection-oracle-connection-controller"
+				connection := &rdsdbaasv1alpha1.RDSConnection{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      connectionName,
 						Namespace: testNamespace,
 					},
-				}
-				Eventually(func() bool {
-					if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(conn), conn); err != nil {
-						return false
-					}
-					condition := apimeta.FindStatusCondition(conn.Status.Conditions, "ReadyForBinding")
-					if condition == nil || condition.Status != metav1.ConditionTrue || condition.Reason != "Ready" {
-						return false
-					}
-					Expect(conn.Status.CredentialsRef).ShouldNot(BeNil())
-					Expect(conn.Status.CredentialsRef.Name).Should(Equal(fmt.Sprintf("%s-credentials", conn.Name)))
-					Expect(conn.Status.ConnectionInfoRef).ShouldNot(BeNil())
-					Expect(conn.Status.ConnectionInfoRef.Name).Should(Equal(fmt.Sprintf("%s-configs", conn.Name)))
-					return true
-				}, timeout).Should(BeTrue())
-
-				By("checking the ConfigMap of the Connection")
-				configmap := &v1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      conn.Status.ConnectionInfoRef.Name,
-						Namespace: testNamespace,
-					},
-				}
-				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(configmap), configmap)
-				Expect(err).ShouldNot(HaveOccurred())
-				ju, juOk := configmap.Data["jdbc-url"]
-				Expect(juOk).Should(BeTrue())
-				Expect(ju).Should(Equal("jdbc:oracle:thin:@address-oracle-connection-controller:9000/ORCL"))
-				t, typeOk := configmap.Data["type"]
-				Expect(typeOk).Should(BeTrue())
-				Expect(t).Should(Equal("oracle"))
-				provider, providerOk := configmap.Data["provider"]
-				Expect(providerOk).Should(BeTrue())
-				Expect(provider).Should(Equal("Red Hat DBaaS / Amazon Relational Database Service (RDS)"))
-				host, hostOk := configmap.Data["host"]
-				Expect(hostOk).Should(BeTrue())
-				Expect(host).Should(Equal("address-oracle-connection-controller"))
-				port, portOk := configmap.Data["port"]
-				Expect(portOk).Should(BeTrue())
-				Expect(port).Should(Equal("9000"))
-				db, dbOk := configmap.Data["database"]
-				Expect(dbOk).Should(BeTrue())
-				Expect(db).Should(Equal("ORCL"))
-			})
-		})
-
-		Context("when Connection for SqlServer is created", func() {
-			instanceID := "instance-id-sqlserver-connection-controller"
-			dbInstance := &rdsv1alpha1.DBInstance{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "db-instance-sqlserver-connection-controller",
-					Namespace: testNamespace,
-				},
-				Spec: rdsv1alpha1.DBInstanceSpec{
-					Engine:               pointer.String("sqlserver-ex"),
-					DBInstanceIdentifier: pointer.String(instanceID),
-					DBInstanceClass:      pointer.String("db.t3.micro"),
-					MasterUserPassword: &ackv1alpha1.SecretKeyReference{
-						SecretReference: v1.SecretReference{
-							Name:      "secret-jdbc-url-connection-controller",
+					Spec: dbaasv1alpha1.DBaaSConnectionSpec{
+						InventoryRef: dbaasv1alpha1.NamespacedName{
+							Name:      inventoryName,
 							Namespace: testNamespace,
 						},
-						Key: "password",
+						InstanceID: instanceIDOracle,
 					},
-					MasterUsername: pointer.String("user-sqlserver-connection-controller"),
-				},
-			}
-			BeforeEach(assertResourceCreation(dbInstance))
-			AfterEach(assertResourceDeletion(dbInstance))
+				}
+				BeforeEach(assertResourceCreation(connection))
+				AfterEach(assertResourceDeletion(connection))
 
-			BeforeEach(func() {
-				Eventually(func() bool {
-					if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dbInstance), dbInstance); err != nil {
-						return false
+				It("should add jdbc-url to the ConfigMap for service binding", func() {
+					By("checking the status of the Connection")
+					conn := &rdsdbaasv1alpha1.RDSConnection{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      connectionName,
+							Namespace: testNamespace,
+						},
 					}
-					dbInstance.Status.DBInstanceStatus = pointer.String("available")
-					dbInstance.Status.Endpoint = &rdsv1alpha1.Endpoint{
-						Address: pointer.String("address-sqlserver-connection-controller"),
-						Port:    pointer.Int64(9000),
+					Eventually(func() bool {
+						if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(conn), conn); err != nil {
+							return false
+						}
+						condition := apimeta.FindStatusCondition(conn.Status.Conditions, "ReadyForBinding")
+						if condition == nil || condition.Status != metav1.ConditionTrue || condition.Reason != "Ready" {
+							return false
+						}
+						Expect(conn.Status.CredentialsRef).ShouldNot(BeNil())
+						Expect(conn.Status.CredentialsRef.Name).Should(Equal(fmt.Sprintf("%s-credentials", conn.Name)))
+						Expect(conn.Status.ConnectionInfoRef).ShouldNot(BeNil())
+						Expect(conn.Status.ConnectionInfoRef.Name).Should(Equal(fmt.Sprintf("%s-configs", conn.Name)))
+						return true
+					}, timeout).Should(BeTrue())
+
+					By("checking the ConfigMap of the Connection")
+					configmap := &v1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      conn.Status.ConnectionInfoRef.Name,
+							Namespace: testNamespace,
+						},
 					}
-					err := k8sClient.Status().Update(ctx, dbInstance)
-					return err == nil
-				}, timeout).Should(BeTrue())
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(configmap), configmap)
+					Expect(err).ShouldNot(HaveOccurred())
+					ju, juOk := configmap.Data["jdbc-url"]
+					Expect(juOk).Should(BeTrue())
+					Expect(ju).Should(Equal("jdbc:oracle:thin:@address-oracle-connection-controller:9000/ORCL"))
+					t, typeOk := configmap.Data["type"]
+					Expect(typeOk).Should(BeTrue())
+					Expect(t).Should(Equal("oracle"))
+					provider, providerOk := configmap.Data["provider"]
+					Expect(providerOk).Should(BeTrue())
+					Expect(provider).Should(Equal("Red Hat DBaaS / Amazon Relational Database Service (RDS)"))
+					host, hostOk := configmap.Data["host"]
+					Expect(hostOk).Should(BeTrue())
+					Expect(host).Should(Equal("address-oracle-connection-controller"))
+					port, portOk := configmap.Data["port"]
+					Expect(portOk).Should(BeTrue())
+					Expect(port).Should(Equal("9000"))
+					db, dbOk := configmap.Data["database"]
+					Expect(dbOk).Should(BeTrue())
+					Expect(db).Should(Equal("ORCL"))
+				})
 			})
 
-			connectionName := "rds-connection-sqlserver-connection-controller"
-			connection := &rdsdbaasv1alpha1.RDSConnection{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      connectionName,
-					Namespace: testNamespace,
-				},
-				Spec: dbaasv1alpha1.DBaaSConnectionSpec{
-					InventoryRef: dbaasv1alpha1.NamespacedName{
-						Name:      inventoryName,
-						Namespace: testNamespace,
-					},
-					InstanceID: instanceID,
-				},
-			}
-			BeforeEach(assertResourceCreation(connection))
-			AfterEach(assertResourceDeletion(connection))
+			Context("when Connection for SqlServer is created", func() {
+				BeforeEach(func() {
+					Eventually(func() bool {
+						if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dbInstanceSqlServer), dbInstanceSqlServer); err != nil {
+							return false
+						}
+						dbInstanceSqlServer.Status.DBInstanceStatus = pointer.String("available")
+						dbInstanceSqlServer.Status.Endpoint = &rdsv1alpha1.Endpoint{
+							Address: pointer.String("address-sqlserver-connection-controller"),
+							Port:    pointer.Int64(9000),
+						}
+						err := k8sClient.Status().Update(ctx, dbInstanceSqlServer)
+						return err == nil
+					}, timeout).Should(BeTrue())
+				})
 
-			It("should add jdbc-url to the ConfigMap for service binding", func() {
-				By("checking the status of the Connection")
-				conn := &rdsdbaasv1alpha1.RDSConnection{
+				connectionName := "rds-connection-sqlserver-connection-controller"
+				connection := &rdsdbaasv1alpha1.RDSConnection{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      connectionName,
 						Namespace: testNamespace,
 					},
-				}
-				Eventually(func() bool {
-					if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(conn), conn); err != nil {
-						return false
-					}
-					condition := apimeta.FindStatusCondition(conn.Status.Conditions, "ReadyForBinding")
-					if condition == nil || condition.Status != metav1.ConditionTrue || condition.Reason != "Ready" {
-						return false
-					}
-					Expect(conn.Status.CredentialsRef).ShouldNot(BeNil())
-					Expect(conn.Status.CredentialsRef.Name).Should(Equal(fmt.Sprintf("%s-credentials", conn.Name)))
-					Expect(conn.Status.ConnectionInfoRef).ShouldNot(BeNil())
-					Expect(conn.Status.ConnectionInfoRef.Name).Should(Equal(fmt.Sprintf("%s-configs", conn.Name)))
-					return true
-				}, timeout).Should(BeTrue())
-
-				By("checking the ConfigMap of the Connection")
-				configmap := &v1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      conn.Status.ConnectionInfoRef.Name,
-						Namespace: testNamespace,
+					Spec: dbaasv1alpha1.DBaaSConnectionSpec{
+						InventoryRef: dbaasv1alpha1.NamespacedName{
+							Name:      inventoryName,
+							Namespace: testNamespace,
+						},
+						InstanceID: instanceIDSqlServer,
 					},
 				}
-				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(configmap), configmap)
-				Expect(err).ShouldNot(HaveOccurred())
-				ju, juOk := configmap.Data["jdbc-url"]
-				Expect(juOk).Should(BeTrue())
-				Expect(ju).Should(Equal("jdbc:sqlserver://address-sqlserver-connection-controller:9000;databaseName=master"))
-				t, typeOk := configmap.Data["type"]
-				Expect(typeOk).Should(BeTrue())
-				Expect(t).Should(Equal("sqlserver"))
-				provider, providerOk := configmap.Data["provider"]
-				Expect(providerOk).Should(BeTrue())
-				Expect(provider).Should(Equal("Red Hat DBaaS / Amazon Relational Database Service (RDS)"))
-				host, hostOk := configmap.Data["host"]
-				Expect(hostOk).Should(BeTrue())
-				Expect(host).Should(Equal("address-sqlserver-connection-controller"))
-				port, portOk := configmap.Data["port"]
-				Expect(portOk).Should(BeTrue())
-				Expect(port).Should(Equal("9000"))
-				db, dbOk := configmap.Data["database"]
-				Expect(dbOk).Should(BeTrue())
-				Expect(db).Should(Equal("master"))
+				BeforeEach(assertResourceCreation(connection))
+				AfterEach(assertResourceDeletion(connection))
+
+				It("should add jdbc-url to the ConfigMap for service binding", func() {
+					By("checking the status of the Connection")
+					conn := &rdsdbaasv1alpha1.RDSConnection{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      connectionName,
+							Namespace: testNamespace,
+						},
+					}
+					Eventually(func() bool {
+						if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(conn), conn); err != nil {
+							return false
+						}
+						condition := apimeta.FindStatusCondition(conn.Status.Conditions, "ReadyForBinding")
+						if condition == nil || condition.Status != metav1.ConditionTrue || condition.Reason != "Ready" {
+							return false
+						}
+						Expect(conn.Status.CredentialsRef).ShouldNot(BeNil())
+						Expect(conn.Status.CredentialsRef.Name).Should(Equal(fmt.Sprintf("%s-credentials", conn.Name)))
+						Expect(conn.Status.ConnectionInfoRef).ShouldNot(BeNil())
+						Expect(conn.Status.ConnectionInfoRef.Name).Should(Equal(fmt.Sprintf("%s-configs", conn.Name)))
+						return true
+					}, timeout).Should(BeTrue())
+
+					By("checking the ConfigMap of the Connection")
+					configmap := &v1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      conn.Status.ConnectionInfoRef.Name,
+							Namespace: testNamespace,
+						},
+					}
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(configmap), configmap)
+					Expect(err).ShouldNot(HaveOccurred())
+					ju, juOk := configmap.Data["jdbc-url"]
+					Expect(juOk).Should(BeTrue())
+					Expect(ju).Should(Equal("jdbc:sqlserver://address-sqlserver-connection-controller:9000;databaseName=master"))
+					t, typeOk := configmap.Data["type"]
+					Expect(typeOk).Should(BeTrue())
+					Expect(t).Should(Equal("sqlserver"))
+					provider, providerOk := configmap.Data["provider"]
+					Expect(providerOk).Should(BeTrue())
+					Expect(provider).Should(Equal("Red Hat DBaaS / Amazon Relational Database Service (RDS)"))
+					host, hostOk := configmap.Data["host"]
+					Expect(hostOk).Should(BeTrue())
+					Expect(host).Should(Equal("address-sqlserver-connection-controller"))
+					port, portOk := configmap.Data["port"]
+					Expect(portOk).Should(BeTrue())
+					Expect(port).Should(Equal("9000"))
+					db, dbOk := configmap.Data["database"]
+					Expect(dbOk).Should(BeTrue())
+					Expect(db).Should(Equal("master"))
+				})
 			})
 		})
 	})

--- a/controllers/rdsconnection_controller_test.go
+++ b/controllers/rdsconnection_controller_test.go
@@ -30,6 +30,7 @@ import (
 
 	dbaasv1alpha1 "github.com/RHEcosystemAppEng/dbaas-operator/api/v1alpha1"
 	rdsdbaasv1alpha1 "github.com/RHEcosystemAppEng/rds-dbaas-operator/api/v1alpha1"
+	"github.com/RHEcosystemAppEng/rds-dbaas-operator/controllers/rds/test"
 	rdsv1alpha1 "github.com/aws-controllers-k8s/rds-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 )
@@ -40,7 +41,7 @@ var _ = Describe("RDSConnectionController", func() {
 
 		dbInstance := &rdsv1alpha1.DBInstance{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "db-instance-connection-controller",
+				Name:      "db-instance-postgres-connection-controller",
 				Namespace: testNamespace,
 			},
 			Spec: rdsv1alpha1.DBInstanceSpec{
@@ -229,7 +230,7 @@ var _ = Describe("RDSConnectionController", func() {
 				})
 
 				Context("when Inventory is ready", func() {
-					accessKey := "AKIAIOSFODNN7EXAMPLECONNECTIONCONTROLLER"
+					accessKey := "AKIAIOSFODNN7EXAMPLE" + test.ConnectionControllerTestAccessKeySuffix
 					secretKey := "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 					region := "us-east-1"
 
@@ -588,7 +589,7 @@ var _ = Describe("RDSConnectionController", func() {
 
 		Context("when Inventory is created and ready", func() {
 			credentialName := "credentials-ref-jdbc-url-connection-controller"
-			accessKey := "AKIAIOSFODNN7EXAMPLECONNECTIONCONTROLLER"
+			accessKey := "AKIAIOSFODNN7EXAMPLE" + test.ConnectionControllerTestAccessKeySuffix
 			secretKey := "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 			region := "us-east-1"
 

--- a/controllers/rdsinstance_controller_test.go
+++ b/controllers/rdsinstance_controller_test.go
@@ -36,6 +36,7 @@ import (
 
 	dbaasv1alpha1 "github.com/RHEcosystemAppEng/dbaas-operator/api/v1alpha1"
 	rdsdbaasv1alpha1 "github.com/RHEcosystemAppEng/rds-dbaas-operator/api/v1alpha1"
+	"github.com/RHEcosystemAppEng/rds-dbaas-operator/controllers/rds/test"
 	rdsv1alpha1 "github.com/aws-controllers-k8s/rds-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ophandler "github.com/operator-framework/operator-lib/handler"
@@ -137,7 +138,7 @@ var _ = Describe("RDSInstanceController", func() {
 			})
 
 			Context("when Inventory is ready", func() {
-				accessKey := "AKIAIOSFODNN7EXAMPLEINSTANCECONTROLLER"
+				accessKey := "AKIAIOSFODNN7EXAMPLE" + test.InstanceControllerTestAccessKeySuffix
 				secretKey := "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 				region := "us-east-1"
 

--- a/controllers/rdsinventory_controller.go
+++ b/controllers/rdsinventory_controller.go
@@ -422,7 +422,9 @@ func (r *RDSInventoryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			for i := range awsDBInstances {
 				dbInstance := awsDBInstances[i]
 				awsDBInstanceMap[*dbInstance.DBInstanceIdentifier] = dbInstance
-				if dbInstance.Engine != nil {
+				if dbInstance.Engine == nil {
+					continue
+				} else {
 					switch *dbInstance.Engine {
 					case aurora, auroraMysql, auroraPostgresql, customOracleEe, customSqlserverEe, customSqlserverSe, customSqlserverWeb:
 						continue
@@ -470,7 +472,9 @@ func (r *RDSInventoryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		waitForAdoptedResource := false
 		for i := range adoptedDBInstanceList.Items {
 			adoptedDBInstance := adoptedDBInstanceList.Items[i]
-			if adoptedDBInstance.Spec.Engine != nil {
+			if adoptedDBInstance.Spec.Engine == nil {
+				continue
+			} else {
 				switch *adoptedDBInstance.Spec.Engine {
 				case aurora, auroraMysql, auroraPostgresql, customOracleEe, customSqlserverEe, customSqlserverSe, customSqlserverWeb:
 					continue
@@ -483,29 +487,37 @@ func (r *RDSInventoryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			if adoptedDBInstance.Status.DBInstanceStatus != nil && *adoptedDBInstance.Status.DBInstanceStatus == "deleting" {
 				continue
 			}
+			if adoptedDBInstance.Status.ACKResourceMetadata == nil || adoptedDBInstance.Status.ACKResourceMetadata.ARN == nil {
+				continue
+			}
+			awsDBInstance, awsOk := awsDBInstanceMap[*adoptedDBInstance.Spec.DBInstanceIdentifier]
+			if !awsOk {
+				continue
+			} else if awsDBInstance.DBInstanceArn == nil ||
+				*awsDBInstance.DBInstanceArn != string(*adoptedDBInstance.Status.ACKResourceMetadata.ARN) {
+				continue
+			}
 
 			if adoptedDBInstance.Spec.MasterUsername == nil || adoptedDBInstance.Spec.DBName == nil {
-				if awsDBInstance, ok := awsDBInstanceMap[*adoptedDBInstance.Spec.DBInstanceIdentifier]; ok {
-					update := false
-					if adoptedDBInstance.Spec.MasterUsername == nil && awsDBInstance.MasterUsername != nil {
-						adoptedDBInstance.Spec.MasterUsername = pointer.String(*awsDBInstance.MasterUsername)
-						update = true
-					}
-					if adoptedDBInstance.Spec.DBName == nil && awsDBInstance.DBName != nil {
-						adoptedDBInstance.Spec.DBName = pointer.String(*awsDBInstance.DBName)
-						update = true
-					}
-					if update {
-						if e := r.Update(ctx, &adoptedDBInstance); e != nil {
-							if errors.IsConflict(e) {
-								logger.Info("Adopted DB Instance modified, retry reconciling")
-								returnRequeueSyncReset()
-								return true, false
-							}
-							logger.Error(e, "Failed to update connection info of the adopted DB Instance", "DB Instance", adoptedDBInstance)
-							returnError(e, inventoryStatusReasonBackendError, inventoryStatusMessageUpdateInstanceError)
+				update := false
+				if adoptedDBInstance.Spec.MasterUsername == nil && awsDBInstance.MasterUsername != nil {
+					adoptedDBInstance.Spec.MasterUsername = pointer.String(*awsDBInstance.MasterUsername)
+					update = true
+				}
+				if adoptedDBInstance.Spec.DBName == nil && awsDBInstance.DBName != nil {
+					adoptedDBInstance.Spec.DBName = pointer.String(*awsDBInstance.DBName)
+					update = true
+				}
+				if update {
+					if e := r.Update(ctx, &adoptedDBInstance); e != nil {
+						if errors.IsConflict(e) {
+							logger.Info("Adopted DB Instance modified, retry reconciling")
+							returnRequeueSyncReset()
 							return true, false
 						}
+						logger.Error(e, "Failed to update connection info of the adopted DB Instance", "DB Instance", adoptedDBInstance)
+						returnError(e, inventoryStatusReasonBackendError, inventoryStatusMessageUpdateInstanceError)
+						return true, false
 					}
 				}
 			}
@@ -551,6 +563,22 @@ func (r *RDSInventoryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	syncDBInstancesStatus := func() bool {
+		awsDBInstanceIdentifiers := map[string]string{}
+		describeDBInstancesPaginator := r.GetDescribeDBInstancesPaginatorAPI(accessKey, secretKey, region)
+		for describeDBInstancesPaginator.HasMorePages() {
+			if output, e := describeDBInstancesPaginator.NextPage(ctx); e != nil {
+				logger.Error(e, "Failed to read DB Instances of the Inventory from AWS")
+				returnError(e, inventoryStatusReasonBackendError, inventoryStatusMessageGetInstancesError)
+				return true
+			} else if output != nil {
+				for _, instance := range output.DBInstances {
+					if instance.DBInstanceIdentifier != nil && instance.DBInstanceArn != nil {
+						awsDBInstanceIdentifiers[*instance.DBInstanceIdentifier] = *instance.DBInstanceArn
+					}
+				}
+			}
+		}
+
 		dbInstanceList := &rdsv1alpha1.DBInstanceList{}
 		if e := r.List(ctx, dbInstanceList, client.InNamespace(inventory.Namespace)); e != nil {
 			logger.Error(e, "Failed to read DB Instances of the Inventory in the cluster")
@@ -561,6 +589,15 @@ func (r *RDSInventoryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		var instances []dbaasv1alpha1.Instance
 		for i := range dbInstanceList.Items {
 			dbInstance := dbInstanceList.Items[i]
+			if dbInstance.Spec.DBInstanceIdentifier == nil ||
+				dbInstance.Status.ACKResourceMetadata == nil || dbInstance.Status.ACKResourceMetadata.ARN == nil {
+				continue
+			}
+			if arn, ok := awsDBInstanceIdentifiers[*dbInstance.Spec.DBInstanceIdentifier]; !ok {
+				continue
+			} else if arn != string(*dbInstance.Status.ACKResourceMetadata.ARN) {
+				continue
+			}
 			instance := dbaasv1alpha1.Instance{
 				InstanceID:   *dbInstance.Spec.DBInstanceIdentifier,
 				Name:         dbInstance.Name,
@@ -757,12 +794,14 @@ func (r *RDSInventoryReconciler) stopRDSController(ctx context.Context, cli clie
 	logger := log.FromContext(ctx)
 
 	deployment := &appsv1.Deployment{}
+	waitCounter := 0
 	for {
 		if err := cli.Get(ctx, client.ObjectKey{Namespace: r.ACKInstallNamespace, Name: ackDeploymentName}, deployment); err != nil {
 			if errors.IsNotFound(err) {
-				if wait {
+				if wait && waitCounter < 15 {
 					logger.Info("Wait for the installation of the RDS controller")
-					time.Sleep(25 * time.Second)
+					time.Sleep(30 * time.Second)
+					waitCounter++
 					continue
 				} else {
 					return err

--- a/controllers/rdsinventory_controller_test.go
+++ b/controllers/rdsinventory_controller_test.go
@@ -137,6 +137,14 @@ var _ = Describe("RDSInventoryController", func() {
 						return false
 					}
 					dbInstance1.Status.DBInstanceStatus = pointer.String("available")
+					arn := ackv1alpha1.AWSResourceName("db-instance-1")
+					ownerAccountID := ackv1alpha1.AWSAccountID("testOwnerId")
+					region := ackv1alpha1.AWSRegion("us-east-1")
+					dbInstance1.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{
+						ARN:            &arn,
+						OwnerAccountID: &ownerAccountID,
+						Region:         &region,
+					}
 					err := k8sClient.Status().Update(ctx, dbInstance1)
 					return err == nil
 				}, timeout).Should(BeTrue())
@@ -161,6 +169,14 @@ var _ = Describe("RDSInventoryController", func() {
 						return false
 					}
 					dbInstance2.Status.DBInstanceStatus = pointer.String("creating")
+					arn := ackv1alpha1.AWSResourceName("db-instance-2")
+					ownerAccountID := ackv1alpha1.AWSAccountID("testOwnerId")
+					region := ackv1alpha1.AWSRegion("us-east-1")
+					dbInstance2.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{
+						ARN:            &arn,
+						OwnerAccountID: &ownerAccountID,
+						Region:         &region,
+					}
 					err := k8sClient.Status().Update(ctx, dbInstance2)
 					return err == nil
 				}, timeout).Should(BeTrue())
@@ -188,6 +204,14 @@ var _ = Describe("RDSInventoryController", func() {
 						return false
 					}
 					dbInstance3.Status.DBInstanceStatus = pointer.String("available")
+					arn := ackv1alpha1.AWSResourceName("mock-adopted-db-instance-3")
+					ownerAccountID := ackv1alpha1.AWSAccountID("testOwnerId")
+					region := ackv1alpha1.AWSRegion("us-east-1")
+					dbInstance3.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{
+						ARN:            &arn,
+						OwnerAccountID: &ownerAccountID,
+						Region:         &region,
+					}
 					err := k8sClient.Status().Update(ctx, dbInstance3)
 					return err == nil
 				}, timeout).Should(BeTrue())
@@ -215,6 +239,14 @@ var _ = Describe("RDSInventoryController", func() {
 						return false
 					}
 					dbInstance4.Status.DBInstanceStatus = pointer.String("deleting")
+					arn := ackv1alpha1.AWSResourceName("mock-adopted-db-instance-4")
+					ownerAccountID := ackv1alpha1.AWSAccountID("testOwnerId")
+					region := ackv1alpha1.AWSRegion("us-east-1")
+					dbInstance4.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{
+						ARN:            &arn,
+						OwnerAccountID: &ownerAccountID,
+						Region:         &region,
+					}
 					err := k8sClient.Status().Update(ctx, dbInstance4)
 					return err == nil
 				}, timeout).Should(BeTrue())
@@ -242,7 +274,85 @@ var _ = Describe("RDSInventoryController", func() {
 						return false
 					}
 					dbInstance5.Status.DBInstanceStatus = pointer.String("creating")
+					arn := ackv1alpha1.AWSResourceName("mock-adopted-db-instance-5")
+					ownerAccountID := ackv1alpha1.AWSAccountID("testOwnerId")
+					region := ackv1alpha1.AWSRegion("us-east-1")
+					dbInstance5.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{
+						ARN:            &arn,
+						OwnerAccountID: &ownerAccountID,
+						Region:         &region,
+					}
 					err := k8sClient.Status().Update(ctx, dbInstance5)
+					return err == nil
+				}, timeout).Should(BeTrue())
+			})
+
+			dbInstance14 := &rdsv1alpha1.DBInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "db-instance-inventory-controller-14",
+					Namespace: testNamespace,
+					Labels: map[string]string{
+						"rds.dbaas.redhat.com/adopted": "true",
+					},
+				},
+				Spec: rdsv1alpha1.DBInstanceSpec{
+					Engine:               pointer.String("mysql"),
+					DBInstanceIdentifier: pointer.String("mock-adopted-db-instance-14"),
+					DBInstanceClass:      pointer.String("db.t3.small"),
+				},
+			}
+			BeforeEach(assertResourceCreation(dbInstance14))
+			AfterEach(assertResourceDeletion(dbInstance14))
+			BeforeEach(func() {
+				Eventually(func() bool {
+					if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dbInstance14), dbInstance14); err != nil {
+						return false
+					}
+					dbInstance14.Status.DBInstanceStatus = pointer.String("available")
+					arn := ackv1alpha1.AWSResourceName("mock-adopted-db-instance-14")
+					ownerAccountID := ackv1alpha1.AWSAccountID("testOwnerId")
+					region := ackv1alpha1.AWSRegion("us-east-1")
+					dbInstance14.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{
+						ARN:            &arn,
+						OwnerAccountID: &ownerAccountID,
+						Region:         &region,
+					}
+					err := k8sClient.Status().Update(ctx, dbInstance14)
+					return err == nil
+				}, timeout).Should(BeTrue())
+			})
+
+			dbInstance15 := &rdsv1alpha1.DBInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "db-instance-inventory-controller-15",
+					Namespace: testNamespace,
+					Labels: map[string]string{
+						"rds.dbaas.redhat.com/adopted": "true",
+					},
+				},
+				Spec: rdsv1alpha1.DBInstanceSpec{
+					Engine:               pointer.String("mysql"),
+					DBInstanceIdentifier: pointer.String("mock-adopted-db-instance-15"),
+					DBInstanceClass:      pointer.String("db.t3.small"),
+				},
+			}
+			BeforeEach(assertResourceCreation(dbInstance15))
+			AfterEach(assertResourceDeletion(dbInstance15))
+			BeforeEach(func() {
+				Eventually(func() bool {
+					if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dbInstance15), dbInstance15); err != nil {
+						return false
+					}
+					dbInstance15.Status.DBInstanceStatus = pointer.String("creating")
+					arn := ackv1alpha1.AWSResourceName("mock-adopted-db-instance-15")
+					ownerAccountID := ackv1alpha1.AWSAccountID("testOwnerId")
+					region := ackv1alpha1.AWSRegion("us-east-1")
+					dbInstance15.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{
+						ARN:            &arn,
+						OwnerAccountID: &ownerAccountID,
+						Region:         &region,
+					}
+					err := k8sClient.Status().Update(ctx, dbInstance15)
 					return err == nil
 				}, timeout).Should(BeTrue())
 			})
@@ -270,6 +380,14 @@ var _ = Describe("RDSInventoryController", func() {
 						return false
 					}
 					dbInstance6.Status.DBInstanceStatus = pointer.String("available")
+					arn := ackv1alpha1.AWSResourceName("mock-adopted-db-instance-6")
+					ownerAccountID := ackv1alpha1.AWSAccountID("testOwnerId")
+					region := ackv1alpha1.AWSRegion("us-east-1")
+					dbInstance6.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{
+						ARN:            &arn,
+						OwnerAccountID: &ownerAccountID,
+						Region:         &region,
+					}
 					err := k8sClient.Status().Update(ctx, dbInstance6)
 					return err == nil
 				}, timeout).Should(BeTrue())
@@ -297,6 +415,14 @@ var _ = Describe("RDSInventoryController", func() {
 						return false
 					}
 					dbInstance7.Status.DBInstanceStatus = pointer.String("available")
+					arn := ackv1alpha1.AWSResourceName("mock-adopted-db-instance-7")
+					ownerAccountID := ackv1alpha1.AWSAccountID("testOwnerId")
+					region := ackv1alpha1.AWSRegion("us-east-1")
+					dbInstance7.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{
+						ARN:            &arn,
+						OwnerAccountID: &ownerAccountID,
+						Region:         &region,
+					}
 					err := k8sClient.Status().Update(ctx, dbInstance7)
 					return err == nil
 				}, timeout).Should(BeTrue())
@@ -324,6 +450,14 @@ var _ = Describe("RDSInventoryController", func() {
 						return false
 					}
 					dbInstance8.Status.DBInstanceStatus = pointer.String("available")
+					arn := ackv1alpha1.AWSResourceName("mock-adopted-db-instance-8")
+					ownerAccountID := ackv1alpha1.AWSAccountID("testOwnerId")
+					region := ackv1alpha1.AWSRegion("us-east-1")
+					dbInstance8.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{
+						ARN:            &arn,
+						OwnerAccountID: &ownerAccountID,
+						Region:         &region,
+					}
 					err := k8sClient.Status().Update(ctx, dbInstance8)
 					return err == nil
 				}, timeout).Should(BeTrue())
@@ -351,6 +485,14 @@ var _ = Describe("RDSInventoryController", func() {
 						return false
 					}
 					dbInstance9.Status.DBInstanceStatus = pointer.String("available")
+					arn := ackv1alpha1.AWSResourceName("mock-adopted-db-instance-9")
+					ownerAccountID := ackv1alpha1.AWSAccountID("testOwnerId")
+					region := ackv1alpha1.AWSRegion("us-east-1")
+					dbInstance9.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{
+						ARN:            &arn,
+						OwnerAccountID: &ownerAccountID,
+						Region:         &region,
+					}
 					err := k8sClient.Status().Update(ctx, dbInstance9)
 					return err == nil
 				}, timeout).Should(BeTrue())
@@ -378,6 +520,14 @@ var _ = Describe("RDSInventoryController", func() {
 						return false
 					}
 					dbInstance10.Status.DBInstanceStatus = pointer.String("available")
+					arn := ackv1alpha1.AWSResourceName("mock-adopted-db-instance-10")
+					ownerAccountID := ackv1alpha1.AWSAccountID("testOwnerId")
+					region := ackv1alpha1.AWSRegion("us-east-1")
+					dbInstance10.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{
+						ARN:            &arn,
+						OwnerAccountID: &ownerAccountID,
+						Region:         &region,
+					}
 					err := k8sClient.Status().Update(ctx, dbInstance10)
 					return err == nil
 				}, timeout).Should(BeTrue())
@@ -405,6 +555,14 @@ var _ = Describe("RDSInventoryController", func() {
 						return false
 					}
 					dbInstance11.Status.DBInstanceStatus = pointer.String("available")
+					arn := ackv1alpha1.AWSResourceName("mock-adopted-db-instance-11")
+					ownerAccountID := ackv1alpha1.AWSAccountID("testOwnerId")
+					region := ackv1alpha1.AWSRegion("us-east-1")
+					dbInstance11.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{
+						ARN:            &arn,
+						OwnerAccountID: &ownerAccountID,
+						Region:         &region,
+					}
 					err := k8sClient.Status().Update(ctx, dbInstance11)
 					return err == nil
 				}, timeout).Should(BeTrue())
@@ -432,6 +590,14 @@ var _ = Describe("RDSInventoryController", func() {
 						return false
 					}
 					dbInstance12.Status.DBInstanceStatus = pointer.String("available")
+					arn := ackv1alpha1.AWSResourceName("mock-adopted-db-instance-12")
+					ownerAccountID := ackv1alpha1.AWSAccountID("testOwnerId")
+					region := ackv1alpha1.AWSRegion("us-east-1")
+					dbInstance12.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{
+						ARN:            &arn,
+						OwnerAccountID: &ownerAccountID,
+						Region:         &region,
+					}
 					err := k8sClient.Status().Update(ctx, dbInstance12)
 					return err == nil
 				}, timeout).Should(BeTrue())
@@ -459,6 +625,14 @@ var _ = Describe("RDSInventoryController", func() {
 						return false
 					}
 					dbInstance13.Status.DBInstanceStatus = pointer.String("available")
+					arn := ackv1alpha1.AWSResourceName("mock-adopted-db-instance-13")
+					ownerAccountID := ackv1alpha1.AWSAccountID("testOwnerId")
+					region := ackv1alpha1.AWSRegion("us-east-1")
+					dbInstance13.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{
+						ARN:            &arn,
+						OwnerAccountID: &ownerAccountID,
+						Region:         &region,
+					}
 					err := k8sClient.Status().Update(ctx, dbInstance13)
 					return err == nil
 				}, timeout).Should(BeTrue())
@@ -709,9 +883,73 @@ var _ = Describe("RDSInventoryController", func() {
 						}, timeout).Should(BeTrue())
 
 						assertResourceCreation(mockDBInstance1)()
+						Eventually(func() bool {
+							if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(mockDBInstance1), mockDBInstance1); err != nil {
+								return false
+							}
+							arn := ackv1alpha1.AWSResourceName("mock-db-instance-1")
+							ownerAccountID := ackv1alpha1.AWSAccountID("testOwnerId")
+							region := ackv1alpha1.AWSRegion("us-east-1")
+							mockDBInstance1.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{
+								ARN:            &arn,
+								OwnerAccountID: &ownerAccountID,
+								Region:         &region,
+							}
+							err := k8sClient.Status().Update(ctx, mockDBInstance1)
+							return err == nil
+						}, timeout).Should(BeTrue())
+
 						assertResourceCreation(mockDBInstance2)()
+						Eventually(func() bool {
+							if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(mockDBInstance2), mockDBInstance2); err != nil {
+								return false
+							}
+							arn := ackv1alpha1.AWSResourceName("mock-db-instance-2")
+							ownerAccountID := ackv1alpha1.AWSAccountID("testOwnerId")
+							region := ackv1alpha1.AWSRegion("us-east-1")
+							mockDBInstance2.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{
+								ARN:            &arn,
+								OwnerAccountID: &ownerAccountID,
+								Region:         &region,
+							}
+							err := k8sClient.Status().Update(ctx, mockDBInstance2)
+							return err == nil
+						}, timeout).Should(BeTrue())
+
 						assertResourceCreation(mockDBInstance3)()
+						Eventually(func() bool {
+							if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(mockDBInstance3), mockDBInstance3); err != nil {
+								return false
+							}
+							arn := ackv1alpha1.AWSResourceName("mock-db-instance-3")
+							ownerAccountID := ackv1alpha1.AWSAccountID("testOwnerId")
+							region := ackv1alpha1.AWSRegion("us-east-1")
+							mockDBInstance3.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{
+								ARN:            &arn,
+								OwnerAccountID: &ownerAccountID,
+								Region:         &region,
+							}
+							err := k8sClient.Status().Update(ctx, mockDBInstance3)
+							return err == nil
+						}, timeout).Should(BeTrue())
+
 						assertResourceCreation(mockDBInstance4)()
+						Eventually(func() bool {
+							if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(mockDBInstance4), mockDBInstance4); err != nil {
+								return false
+							}
+							arn := ackv1alpha1.AWSResourceName("mock-db-instance-4")
+							ownerAccountID := ackv1alpha1.AWSAccountID("testOwnerId")
+							region := ackv1alpha1.AWSRegion("us-east-1")
+							mockDBInstance4.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{
+								ARN:            &arn,
+								OwnerAccountID: &ownerAccountID,
+								Region:         &region,
+							}
+							err := k8sClient.Status().Update(ctx, mockDBInstance4)
+							return err == nil
+						}, timeout).Should(BeTrue())
+
 						Eventually(func() bool {
 							clusterDBInstanceList := &rdsv1alpha1.DBInstanceList{}
 							if e := k8sClient.List(ctx, clusterDBInstanceList, client.InNamespace(inventory.Namespace)); e != nil {
@@ -751,7 +989,7 @@ var _ = Describe("RDSInventoryController", func() {
 							if condition == nil || condition.Status != metav1.ConditionTrue || condition.Reason != "SyncOK" {
 								return false
 							}
-							if len(inv.Status.Instances) < 10 {
+							if len(inv.Status.Instances) < 7 {
 								return false
 							}
 							instancesMap := map[string]dbaasv1alpha1.Instance{}
@@ -759,21 +997,11 @@ var _ = Describe("RDSInventoryController", func() {
 								ins := inv.Status.Instances[i]
 								instancesMap[ins.InstanceID] = ins
 							}
-							if ins, ok := instancesMap[*dbInstance1.Spec.DBInstanceIdentifier]; !ok {
+							if _, ok := instancesMap[*dbInstance1.Spec.DBInstanceIdentifier]; ok {
 								return false
-							} else {
-								Expect(ins.Name).Should(Equal(dbInstance1.Name))
-								s, ok := ins.InstanceInfo["dbInstanceStatus"]
-								Expect(ok).Should(BeTrue())
-								Expect(s).Should(Equal(*dbInstance1.Status.DBInstanceStatus))
 							}
-							if ins, ok := instancesMap[*dbInstance2.Spec.DBInstanceIdentifier]; !ok {
+							if _, ok := instancesMap[*dbInstance2.Spec.DBInstanceIdentifier]; ok {
 								return false
-							} else {
-								Expect(ins.Name).Should(Equal(dbInstance2.Name))
-								s, ok := ins.InstanceInfo["dbInstanceStatus"]
-								Expect(ok).Should(BeTrue())
-								Expect(s).Should(Equal(*dbInstance2.Status.DBInstanceStatus))
 							}
 							if ins, ok := instancesMap[*dbInstance3.Spec.DBInstanceIdentifier]; !ok {
 								return false
@@ -798,6 +1026,12 @@ var _ = Describe("RDSInventoryController", func() {
 								s, ok := ins.InstanceInfo["dbInstanceStatus"]
 								Expect(ok).Should(BeTrue())
 								Expect(s).Should(Equal(*dbInstance5.Status.DBInstanceStatus))
+							}
+							if _, ok := instancesMap[*dbInstance14.Spec.DBInstanceIdentifier]; ok {
+								return false
+							}
+							if _, ok := instancesMap[*dbInstance15.Spec.DBInstanceIdentifier]; ok {
+								return false
 							}
 							return true
 						}, timeout).Should(BeTrue())
@@ -905,6 +1139,71 @@ var _ = Describe("RDSInventoryController", func() {
 								return false
 							}
 							err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dbSecret5), dbSecret5)
+							if err == nil || !errors.IsNotFound(err) {
+								return false
+							}
+							return true
+						}, timeout).Should(BeTrue())
+
+						By("checking if the username and password of adopted db instance is not reset when the instance not exist in AWS")
+						dbInstance14 := &rdsv1alpha1.DBInstance{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "db-instance-inventory-controller-14",
+								Namespace: testNamespace,
+							},
+						}
+						dbSecret14 := &v1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "db-instance-inventory-controller-14-credentials",
+								Namespace: testNamespace,
+							},
+						}
+						Consistently(func() bool {
+							if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dbInstance14), dbInstance14); err != nil {
+								return false
+							}
+							if dbInstance14.Spec.DBName != nil {
+								return false
+							}
+							if dbInstance14.Spec.MasterUsername != nil {
+								return false
+							}
+							if dbInstance14.Spec.MasterUserPassword != nil {
+								return false
+							}
+							err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dbSecret14), dbSecret14)
+							if err == nil || !errors.IsNotFound(err) {
+								return false
+							}
+							return true
+						}, timeout).Should(BeTrue())
+
+						dbInstance15 := &rdsv1alpha1.DBInstance{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "db-instance-inventory-controller-15",
+								Namespace: testNamespace,
+							},
+						}
+						dbSecret15 := &v1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "db-instance-inventory-controller-15-credentials",
+								Namespace: testNamespace,
+							},
+						}
+						Consistently(func() bool {
+							if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dbInstance15), dbInstance15); err != nil {
+								return false
+							}
+							if dbInstance15.Spec.DBName != nil {
+								return false
+							}
+							if dbInstance15.Spec.MasterUsername != nil {
+								return false
+							}
+							if dbInstance15.Spec.MasterUserPassword != nil {
+								return false
+							}
+							err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dbSecret15), dbSecret15)
 							if err == nil || !errors.IsNotFound(err) {
 								return false
 							}

--- a/controllers/rdsinventory_controller_test.go
+++ b/controllers/rdsinventory_controller_test.go
@@ -30,6 +30,7 @@ import (
 
 	dbaasv1alpha1 "github.com/RHEcosystemAppEng/dbaas-operator/api/v1alpha1"
 	rdsdbaasv1alpha1 "github.com/RHEcosystemAppEng/rds-dbaas-operator/api/v1alpha1"
+	"github.com/RHEcosystemAppEng/rds-dbaas-operator/controllers/rds/test"
 	rdsv1alpha1 "github.com/aws-controllers-k8s/rds-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ophandler "github.com/operator-framework/operator-lib/handler"
@@ -99,7 +100,7 @@ var _ = Describe("RDSInventoryController", func() {
 		credentialName := "credentials-ref-inventory-controller"
 		inventoryName := "rds-inventory-inventory-controller"
 
-		accessKey := "AKIAIOSFODNN7EXAMPLEINVENTORYCONTROLLER"
+		accessKey := "AKIAIOSFODNN7EXAMPLE" + test.InventoryControllerTestAccessKeySuffix
 		secretKey := "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 		region := "us-east-1"
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -193,6 +193,8 @@ var _ = BeforeSuite(func() {
 		GetDescribeDBInstancesAPI:          controllersrdstest.NewDescribeDBInstances,
 		ACKInstallNamespace:                testNamespace,
 		RDSCRDFilePath:                     filepath.Join("..", "rds", "config", "common", "bases"),
+		WaitForRDSControllerRetries:        10,
+		WaitForRDSControllerInterval:       30 * time.Second,
 	}
 	err = inventoryReconciler.SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Implement the workaround to ignore the DB instances that exist in Openshift but don't belong to the AWS account when updating DB instances in the Inventory's status.

Jira: https://issues.redhat.com/browse/DBAAS-753