### PR TITLE
DBAAS-773: add db engine type to instance identifier, cr name and instance status

### DIFF
--- a/controllers/db_utils.go
+++ b/controllers/db_utils.go
@@ -101,6 +101,53 @@ func getDefaultDBName(engine string) *string {
 	}
 }
 
+func getDBEngineAbbreviation(engine *string) string {
+	if engine == nil {
+		return ""
+	}
+
+	switch *engine {
+	case mysql:
+		return "mysql-"
+	case mariadb:
+		return "mariadb-"
+	case aurora:
+		return "aurora-"
+	case auroraMysql:
+		return "aurora-mysql-"
+	case postgres:
+		return "postgres-"
+	case auroraPostgresql:
+		return "aurora-postgres-"
+	case sqlserverEe:
+		return "mssql-ee-"
+	case sqlserverSe:
+		return "mssql-se-"
+	case sqlserverEx:
+		return "mssql-ex-"
+	case sqlserverWeb:
+		return "mssql-web-"
+	case customSqlserverEe:
+		return "cust-mssql-ee-"
+	case customSqlserverSe:
+		return "cust-mssql-se-"
+	case customSqlserverWeb:
+		return "cust-mssql-web-"
+	case oracleSe2:
+		return "oracle-se2-"
+	case oracleSe2Cdb:
+		return "oracle-se2-cdb-"
+	case oracleEe:
+		return "oracle-ee-"
+	case oracleEeCdb:
+		return "oracle-ee-cdb-"
+	case customOracleEe:
+		return "cust-oracle-ee-"
+	default:
+		return ""
+	}
+}
+
 func generatePassword() string {
 	length := 12
 	buf := make([]byte, length)

--- a/controllers/db_utils_test.go
+++ b/controllers/db_utils_test.go
@@ -150,6 +150,37 @@ var _ = Describe("DbUtils", func() {
 		)
 	})
 
+	Context("Generate DB Engine Abbreviation", func() {
+		DescribeTable("checking getDBEngineAbbreviation",
+			func(engine *string, abbr string) {
+				n := getDBEngineAbbreviation(engine)
+				Expect(n).Should(Equal(abbr))
+			},
+
+			Entry("aurora", pointer.String("aurora"), "aurora-"),
+			Entry("aurora-mysql", pointer.String("aurora-mysql"), "aurora-mysql-"),
+			Entry("aurora-postgresql", pointer.String("aurora-postgresql"), "aurora-postgres-"),
+			Entry("custom-oracle-ee", pointer.String("custom-oracle-ee"), "cust-oracle-ee-"),
+			Entry("mariadb", pointer.String("mariadb"), "mariadb-"),
+			Entry("mysql", pointer.String("mysql"), "mysql-"),
+			Entry("oracle-ee", pointer.String("oracle-ee"), "oracle-ee-"),
+			Entry("oracle-ee-cdb", pointer.String("oracle-ee-cdb"), "oracle-ee-cdb-"),
+			Entry("oracle-se2", pointer.String("oracle-se2"), "oracle-se2-"),
+			Entry("oracle-se2-cdb", pointer.String("oracle-se2-cdb"), "oracle-se2-cdb-"),
+			Entry("postgres", pointer.String("postgres"), "postgres-"),
+			Entry("sqlserver-ee", pointer.String("sqlserver-ee"), "mssql-ee-"),
+			Entry("sqlserver-se", pointer.String("sqlserver-se"), "mssql-se-"),
+			Entry("sqlserver-ex", pointer.String("sqlserver-ex"), "mssql-ex-"),
+			Entry("sqlserver-web", pointer.String("sqlserver-web"), "mssql-web-"),
+			Entry("custom-sqlserver-ee", pointer.String("custom-sqlserver-ee"), "cust-mssql-ee-"),
+			Entry("custom-sqlserver-se", pointer.String("custom-sqlserver-se"), "cust-mssql-se-"),
+			Entry("custom-sqlserver-web", pointer.String("custom-sqlserver-web"), "cust-mssql-web-"),
+			Entry("Invalid", pointer.String("invalid"), ""),
+			Entry("Blank", pointer.String(""), ""),
+			Entry("Nil", nil, ""),
+		)
+	})
+
 	Context("Generate Password", func() {
 		DescribeTable("checking generatePassword",
 			func() {

--- a/controllers/rds/test/dbinstance_mock.go
+++ b/controllers/rds/test/dbinstance_mock.go
@@ -31,18 +31,21 @@ import (
 var inventoryTestDBInstances = []*rds.DescribeDBInstancesOutput{
 	{
 		DBInstances: []types.DBInstance{
+			// Adopted successful
 			{
 				DBInstanceIdentifier: pointer.String("mock-db-instance-1"),
 				DBInstanceStatus:     pointer.String("available"),
 				Engine:               pointer.String("postgres"),
 				DBInstanceArn:        pointer.String("mock-db-instance-1"),
 			},
+			// Adopted successful
 			{
 				DBInstanceIdentifier: pointer.String("mock-db-instance-2"),
 				DBInstanceStatus:     pointer.String("available"),
 				Engine:               pointer.String("postgres"),
 				DBInstanceArn:        pointer.String("mock-db-instance-2"),
 			},
+			// Adopted successful
 			{
 				DBInstanceIdentifier: pointer.String("mock-db-instance-3"),
 				DBInstanceStatus:     pointer.String("available"),
@@ -53,22 +56,32 @@ var inventoryTestDBInstances = []*rds.DescribeDBInstancesOutput{
 	},
 	{
 		DBInstances: []types.DBInstance{
+			// Adopted successful
 			{
 				DBInstanceIdentifier: pointer.String("mock-db-instance-4"),
 				DBInstanceStatus:     pointer.String("available"),
 				Engine:               pointer.String("postgres"),
 				DBInstanceArn:        pointer.String("mock-db-instance-4"),
 			},
+			// Deleting, Not Adopted
 			{
 				DBInstanceIdentifier: pointer.String("mock-db-instance-5"),
 				DBInstanceStatus:     pointer.String("deleting"),
 				Engine:               pointer.String("mysql"),
 				DBInstanceArn:        pointer.String("mock-db-instance-5"),
 			},
+			// Adopted successfully
+			{
+				DBInstanceIdentifier: pointer.String("mock-db-instance-7"),
+				DBInstanceStatus:     pointer.String("available"),
+				Engine:               pointer.String("mysql"),
+				DBInstanceArn:        pointer.String("mock-db-instance-7"),
+			},
 		},
 	},
 	{
 		DBInstances: []types.DBInstance{
+			// Reset credentials successfully
 			{
 				DBInstanceIdentifier: pointer.String("mock-adopted-db-instance-3"),
 				DBInstanceStatus:     pointer.String("available"),
@@ -77,6 +90,7 @@ var inventoryTestDBInstances = []*rds.DescribeDBInstancesOutput{
 				MasterUsername:       pointer.String("test-username"),
 				DBInstanceArn:        pointer.String("mock-adopted-db-instance-3"),
 			},
+			// Deleting, Not reset credentials
 			{
 				DBInstanceIdentifier: pointer.String("mock-adopted-db-instance-4"),
 				DBInstanceStatus:     pointer.String("deleting"),
@@ -85,6 +99,7 @@ var inventoryTestDBInstances = []*rds.DescribeDBInstancesOutput{
 				MasterUsername:       pointer.String("test-username"),
 				DBInstanceArn:        pointer.String("mock-adopted-db-instance-4"),
 			},
+			// Not available, Not reset credentials
 			{
 				DBInstanceIdentifier: pointer.String("mock-adopted-db-instance-5"),
 				DBInstanceStatus:     pointer.String("creating"),
@@ -93,6 +108,7 @@ var inventoryTestDBInstances = []*rds.DescribeDBInstancesOutput{
 				MasterUsername:       pointer.String("test-username"),
 				DBInstanceArn:        pointer.String("mock-adopted-db-instance-5"),
 			},
+			// ARN not match, Not reset credentials
 			{
 				DBInstanceIdentifier: pointer.String("mock-adopted-db-instance-15"),
 				DBInstanceStatus:     pointer.String("available"),
@@ -104,6 +120,7 @@ var inventoryTestDBInstances = []*rds.DescribeDBInstancesOutput{
 		},
 	},
 	{
+		// Cluster not supported
 		DBInstances: []types.DBInstance{
 			{
 				DBInstanceIdentifier: pointer.String("mock-db-cluster-1"),
@@ -120,6 +137,7 @@ var inventoryTestDBInstances = []*rds.DescribeDBInstancesOutput{
 		},
 	},
 	{
+		// Engine not supported
 		DBInstances: []types.DBInstance{
 			{
 				DBInstanceIdentifier: pointer.String("mock-db-aurora-1"),

--- a/controllers/rdsinstance_controller_test.go
+++ b/controllers/rdsinstance_controller_test.go
@@ -238,8 +238,8 @@ var _ = Describe("RDSInstanceController", func() {
 							if dbInstance.Spec.DBInstanceIdentifier == nil {
 								return false
 							}
-							Expect(strings.HasPrefix(*dbInstance.Spec.DBInstanceIdentifier, "rhoda-database-")).Should(BeTrue())
-							id := strings.TrimPrefix(*dbInstance.Spec.DBInstanceIdentifier, "rhoda-database-")
+							Expect(strings.HasPrefix(*dbInstance.Spec.DBInstanceIdentifier, "rhoda-postgres-")).Should(BeTrue())
+							id := strings.TrimPrefix(*dbInstance.Spec.DBInstanceIdentifier, "rhoda-postgres-")
 							_, err := uuid.Parse(id)
 							Expect(err).ShouldNot(HaveOccurred())
 							if dbInstance.Spec.PubliclyAccessible == nil || *dbInstance.Spec.PubliclyAccessible != true {
@@ -403,8 +403,8 @@ var _ = Describe("RDSInstanceController", func() {
 								Expect(dbInstance.Spec.Engine).ShouldNot(BeNil())
 								Expect(*dbInstance.Spec.Engine).Should(Equal("postgres"))
 								Expect(dbInstance.Spec.DBInstanceIdentifier).ShouldNot(BeNil())
-								Expect(strings.HasPrefix(*dbInstance.Spec.DBInstanceIdentifier, "rhoda-database-")).Should(BeTrue())
-								id := strings.TrimPrefix(*dbInstance.Spec.DBInstanceIdentifier, "rhoda-database-")
+								Expect(strings.HasPrefix(*dbInstance.Spec.DBInstanceIdentifier, "rhoda-postgres-")).Should(BeTrue())
+								id := strings.TrimPrefix(*dbInstance.Spec.DBInstanceIdentifier, "rhoda-postgres-")
 								_, err := uuid.Parse(id)
 								Expect(err).ShouldNot(HaveOccurred())
 								Expect(dbInstance.Spec.DBInstanceClass).ShouldNot(BeNil())
@@ -782,8 +782,8 @@ var _ = Describe("RDSInstanceController", func() {
 									Expect(condition4.Reason).Should(Equal("DBInstance"))
 									Expect(condition4.Message).Should(Equal("Reason: test##reason&&"))
 
-									Expect(strings.HasPrefix(ins.Status.InstanceID, "rhoda-database-")).Should(BeTrue())
-									id := strings.TrimPrefix(ins.Status.InstanceID, "rhoda-database-")
+									Expect(strings.HasPrefix(ins.Status.InstanceID, "rhoda-postgres-")).Should(BeTrue())
+									id := strings.TrimPrefix(ins.Status.InstanceID, "rhoda-postgres-")
 									_, err := uuid.Parse(id)
 									Expect(err).ShouldNot(HaveOccurred())
 
@@ -791,6 +791,8 @@ var _ = Describe("RDSInstanceController", func() {
 										return false
 									}
 									info := map[string]string{
+										"engine":                                        "postgres",
+										"engineVersion":                                 "13.2",
 										"ackResourceMetadata.arn":                       "test-arn",
 										"ackResourceMetadata.ownerAccountID":            "test-id",
 										"ackResourceMetadata.region":                    "test-region",

--- a/controllers/rdsinventory_controller_test.go
+++ b/controllers/rdsinventory_controller_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controllers_test
 
 import (
+	"strings"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -119,6 +121,7 @@ var _ = Describe("RDSInventoryController", func() {
 		AfterEach(assertResourceDeletion(credential))
 
 		Context("when checking the status of the Inventory", func() {
+			// Not exist in AWS
 			dbInstance1 := &rdsv1alpha1.DBInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "db-instance-inventory-controller-1",
@@ -151,6 +154,7 @@ var _ = Describe("RDSInventoryController", func() {
 				}, timeout).Should(BeTrue())
 			})
 
+			// Not exist in AWS
 			dbInstance2 := &rdsv1alpha1.DBInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "db-instance-inventory-controller-2",
@@ -183,6 +187,7 @@ var _ = Describe("RDSInventoryController", func() {
 				}, timeout).Should(BeTrue())
 			})
 
+			// Available
 			dbInstance3 := &rdsv1alpha1.DBInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "db-instance-inventory-controller-3",
@@ -218,6 +223,7 @@ var _ = Describe("RDSInventoryController", func() {
 				}, timeout).Should(BeTrue())
 			})
 
+			// Deleting
 			dbInstance4 := &rdsv1alpha1.DBInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "db-instance-inventory-controller-4",
@@ -253,6 +259,7 @@ var _ = Describe("RDSInventoryController", func() {
 				}, timeout).Should(BeTrue())
 			})
 
+			// Creating
 			dbInstance5 := &rdsv1alpha1.DBInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "db-instance-inventory-controller-5",
@@ -288,6 +295,7 @@ var _ = Describe("RDSInventoryController", func() {
 				}, timeout).Should(BeTrue())
 			})
 
+			// Not exist in AWS
 			dbInstance14 := &rdsv1alpha1.DBInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "db-instance-inventory-controller-14",
@@ -323,6 +331,7 @@ var _ = Describe("RDSInventoryController", func() {
 				}, timeout).Should(BeTrue())
 			})
 
+			// ARN not match AWS
 			dbInstance15 := &rdsv1alpha1.DBInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "db-instance-inventory-controller-15",
@@ -358,6 +367,7 @@ var _ = Describe("RDSInventoryController", func() {
 				}, timeout).Should(BeTrue())
 			})
 
+			// Cluster
 			dbInstance6 := &rdsv1alpha1.DBInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "db-instance-inventory-controller-6",
@@ -394,6 +404,7 @@ var _ = Describe("RDSInventoryController", func() {
 				}, timeout).Should(BeTrue())
 			})
 
+			// Aurora
 			dbInstance7 := &rdsv1alpha1.DBInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "db-instance-inventory-controller-7",
@@ -429,6 +440,7 @@ var _ = Describe("RDSInventoryController", func() {
 				}, timeout).Should(BeTrue())
 			})
 
+			// Aurora
 			dbInstance8 := &rdsv1alpha1.DBInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "db-instance-inventory-controller-8",
@@ -464,6 +476,7 @@ var _ = Describe("RDSInventoryController", func() {
 				}, timeout).Should(BeTrue())
 			})
 
+			// Aurora
 			dbInstance9 := &rdsv1alpha1.DBInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "db-instance-inventory-controller-9",
@@ -499,6 +512,7 @@ var _ = Describe("RDSInventoryController", func() {
 				}, timeout).Should(BeTrue())
 			})
 
+			// Custom Oracle
 			dbInstance10 := &rdsv1alpha1.DBInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "db-instance-inventory-controller-10",
@@ -534,6 +548,7 @@ var _ = Describe("RDSInventoryController", func() {
 				}, timeout).Should(BeTrue())
 			})
 
+			// Custom SqlServer
 			dbInstance11 := &rdsv1alpha1.DBInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "db-instance-inventory-controller-11",
@@ -569,6 +584,7 @@ var _ = Describe("RDSInventoryController", func() {
 				}, timeout).Should(BeTrue())
 			})
 
+			// Custom SqlServer
 			dbInstance12 := &rdsv1alpha1.DBInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "db-instance-inventory-controller-12",
@@ -604,6 +620,7 @@ var _ = Describe("RDSInventoryController", func() {
 				}, timeout).Should(BeTrue())
 			})
 
+			// Custom SqlServer
 			dbInstance13 := &rdsv1alpha1.DBInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "db-instance-inventory-controller-13",
@@ -640,9 +657,10 @@ var _ = Describe("RDSInventoryController", func() {
 			})
 
 			Context("when mocking RDS controller adopting resources", func() {
+				// Available
 				mockDBInstance1 := &rdsv1alpha1.DBInstance{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "rhoda-adopted-db-instance-mock-db-instance-1",
+						Name:      "rhoda-adopted-postgres-mock-db-instance-1",
 						Namespace: testNamespace,
 					},
 					Spec: rdsv1alpha1.DBInstanceSpec{
@@ -653,9 +671,10 @@ var _ = Describe("RDSInventoryController", func() {
 				}
 				AfterEach(assertResourceDeletionIfExist(mockDBInstance1))
 
+				// Available
 				mockDBInstance2 := &rdsv1alpha1.DBInstance{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "rhoda-adopted-db-instance-mock-db-instance-2",
+						Name:      "rhoda-adopted-postgres-mock-db-instance-2",
 						Namespace: testNamespace,
 					},
 					Spec: rdsv1alpha1.DBInstanceSpec{
@@ -666,9 +685,10 @@ var _ = Describe("RDSInventoryController", func() {
 				}
 				AfterEach(assertResourceDeletionIfExist(mockDBInstance2))
 
+				// Available
 				mockDBInstance3 := &rdsv1alpha1.DBInstance{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "rhoda-adopted-db-instance-mock-db-instance-3",
+						Name:      "rhoda-adopted-postgres-mock-db-instance-3",
 						Namespace: testNamespace,
 					},
 					Spec: rdsv1alpha1.DBInstanceSpec{
@@ -679,9 +699,10 @@ var _ = Describe("RDSInventoryController", func() {
 				}
 				AfterEach(assertResourceDeletionIfExist(mockDBInstance3))
 
+				// Deleting
 				mockDBInstance4 := &rdsv1alpha1.DBInstance{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "rhoda-adopted-db-instance-mock-db-instance-4",
+						Name:      "rhoda-adopted-postgres-mock-db-instance-4",
 						Namespace: testNamespace,
 					},
 					Spec: rdsv1alpha1.DBInstanceSpec{
@@ -691,6 +712,55 @@ var _ = Describe("RDSInventoryController", func() {
 					},
 				}
 				AfterEach(assertResourceDeletionIfExist(mockDBInstance4))
+
+				// Adopted ARN not match AWS
+				mockDBInstance7 := &rdsv1alpha1.DBInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "rhoda-adopted-mysql-mock-db-instance-7",
+						Namespace: testNamespace,
+					},
+					Spec: rdsv1alpha1.DBInstanceSpec{
+						Engine:               pointer.String("postgres"),
+						DBInstanceIdentifier: pointer.String("mock-db-instance-7"),
+						DBInstanceClass:      pointer.String("db.t3.micro"),
+					},
+				}
+				AfterEach(assertResourceDeletionIfExist(mockDBInstance7))
+				adoptedMockInstance7ARN := ackv1alpha1.AWSResourceName("mock-db-instance-7-0")
+				adoptedMockInstance7 := &ackv1alpha1.AdoptedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "rhoda-adopted-mock-db-instance-7",
+						Namespace: testNamespace,
+					},
+					Spec: ackv1alpha1.AdoptedResourceSpec{
+						AWS: &ackv1alpha1.AWSIdentifiers{
+							NameOrID: "mock-db-instance-7",
+							ARN:      &adoptedMockInstance7ARN,
+						},
+						Kubernetes: &ackv1alpha1.ResourceWithMetadata{
+							GroupKind: metav1.GroupKind{
+								Group: rdsv1alpha1.GroupVersion.Group,
+								Kind:  "DBInstance",
+							},
+						},
+					},
+				}
+				BeforeEach(assertResourceCreation(adoptedMockInstance7))
+				AfterEach(assertResourceDeletionIfExist(adoptedMockInstance7))
+
+				// ARN match AWS
+				dbInstance15_0 := &rdsv1alpha1.DBInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "mock-adopted-db-instance-15-0",
+						Namespace: testNamespace,
+					},
+					Spec: rdsv1alpha1.DBInstanceSpec{
+						Engine:               pointer.String("mysql"),
+						DBInstanceIdentifier: pointer.String("mock-adopted-db-instance-15"),
+						DBInstanceClass:      pointer.String("db.t3.micro"),
+					},
+				}
+				AfterEach(assertResourceDeletionIfExist(dbInstance15_0))
 
 				Context("when Inventory is created", func() {
 					inventory := &rdsdbaasv1alpha1.RDSInventory{
@@ -765,7 +835,7 @@ var _ = Describe("RDSInventoryController", func() {
 							if err := k8sClient.List(ctx, adoptedDBInstances, client.InNamespace(testNamespace)); err != nil {
 								return false
 							}
-							if len(adoptedDBInstances.Items) < 4 {
+							if len(adoptedDBInstances.Items) < 5 {
 								return false
 							}
 							dbInstancesMap := map[string]ackv1alpha1.AdoptedResource{}
@@ -777,7 +847,7 @@ var _ = Describe("RDSInventoryController", func() {
 							if instance, ok := dbInstancesMap["mock-db-instance-1"]; !ok {
 								return false
 							} else {
-								if instance.Name != "rhoda-adopted-db-instance-mock-db-instance-1" {
+								if !strings.HasPrefix(instance.Name, "rhoda-adopted-postgres-mock-db-instance-1") {
 									return false
 								}
 								typeString, typeOk := instance.GetAnnotations()[ophandler.TypeAnnotation]
@@ -792,11 +862,14 @@ var _ = Describe("RDSInventoryController", func() {
 								label, labelOk := instance.Spec.Kubernetes.Metadata.Labels["rds.dbaas.redhat.com/adopted"]
 								Expect(labelOk).Should(BeTrue())
 								Expect(label).Should(Equal("true"))
+								Expect(instance.Spec.AWS.NameOrID).Should(Equal("mock-db-instance-1"))
+								Expect(instance.Spec.AWS.ARN).ShouldNot(BeNil())
+								Expect(string(*instance.Spec.AWS.ARN)).Should(Equal("mock-db-instance-1"))
 							}
 							if instance, ok := dbInstancesMap["mock-db-instance-2"]; !ok {
 								return false
 							} else {
-								if instance.Name != "rhoda-adopted-db-instance-mock-db-instance-2" {
+								if !strings.HasPrefix(instance.Name, "rhoda-adopted-postgres-mock-db-instance-2") {
 									return false
 								}
 								typeString, typeOk := instance.GetAnnotations()[ophandler.TypeAnnotation]
@@ -811,11 +884,14 @@ var _ = Describe("RDSInventoryController", func() {
 								label, labelOk := instance.Spec.Kubernetes.Metadata.Labels["rds.dbaas.redhat.com/adopted"]
 								Expect(labelOk).Should(BeTrue())
 								Expect(label).Should(Equal("true"))
+								Expect(instance.Spec.AWS.NameOrID).Should(Equal("mock-db-instance-2"))
+								Expect(instance.Spec.AWS.ARN).ShouldNot(BeNil())
+								Expect(string(*instance.Spec.AWS.ARN)).Should(Equal("mock-db-instance-2"))
 							}
 							if instance, ok := dbInstancesMap["mock-db-instance-3"]; !ok {
 								return false
 							} else {
-								if instance.Name != "rhoda-adopted-db-instance-mock-db-instance-3" {
+								if !strings.HasPrefix(instance.Name, "rhoda-adopted-postgres-mock-db-instance-3") {
 									return false
 								}
 								typeString, typeOk := instance.GetAnnotations()[ophandler.TypeAnnotation]
@@ -830,11 +906,14 @@ var _ = Describe("RDSInventoryController", func() {
 								label, labelOk := instance.Spec.Kubernetes.Metadata.Labels["rds.dbaas.redhat.com/adopted"]
 								Expect(labelOk).Should(BeTrue())
 								Expect(label).Should(Equal("true"))
+								Expect(instance.Spec.AWS.NameOrID).Should(Equal("mock-db-instance-3"))
+								Expect(instance.Spec.AWS.ARN).ShouldNot(BeNil())
+								Expect(string(*instance.Spec.AWS.ARN)).Should(Equal("mock-db-instance-3"))
 							}
 							if instance, ok := dbInstancesMap["mock-db-instance-4"]; !ok {
 								return false
 							} else {
-								if instance.Name != "rhoda-adopted-db-instance-mock-db-instance-4" {
+								if !strings.HasPrefix(instance.Name, "rhoda-adopted-postgres-mock-db-instance-4") {
 									return false
 								}
 								typeString, typeOk := instance.GetAnnotations()[ophandler.TypeAnnotation]
@@ -849,6 +928,31 @@ var _ = Describe("RDSInventoryController", func() {
 								label, labelOk := instance.Spec.Kubernetes.Metadata.Labels["rds.dbaas.redhat.com/adopted"]
 								Expect(labelOk).Should(BeTrue())
 								Expect(label).Should(Equal("true"))
+								Expect(instance.Spec.AWS.NameOrID).Should(Equal("mock-db-instance-4"))
+								Expect(instance.Spec.AWS.ARN).ShouldNot(BeNil())
+								Expect(string(*instance.Spec.AWS.ARN)).Should(Equal("mock-db-instance-4"))
+							}
+							if instance, ok := dbInstancesMap["mock-db-instance-7"]; !ok {
+								return false
+							} else {
+								if !strings.HasPrefix(instance.Name, "rhoda-adopted-mysql-mock-db-instance-7") {
+									return false
+								}
+								typeString, typeOk := instance.GetAnnotations()[ophandler.TypeAnnotation]
+								Expect(typeOk).Should(BeTrue())
+								Expect(typeString).Should(Equal("RDSInventory.dbaas.redhat.com"))
+								namespacedNameString, nsnOk := instance.GetAnnotations()[ophandler.NamespacedNameAnnotation]
+								Expect(nsnOk).Should(BeTrue())
+								Expect(namespacedNameString).Should(Equal(testNamespace + "/" + inventoryName))
+								Expect(instance.Spec.Kubernetes.GroupKind.Kind).Should(Equal("DBInstance"))
+								Expect(instance.Spec.Kubernetes.GroupKind.Group).Should(Equal(rdsv1alpha1.GroupVersion.Group))
+								Expect(instance.Spec.Kubernetes.Metadata.Namespace).Should(Equal(testNamespace))
+								label, labelOk := instance.Spec.Kubernetes.Metadata.Labels["rds.dbaas.redhat.com/adopted"]
+								Expect(labelOk).Should(BeTrue())
+								Expect(label).Should(Equal("true"))
+								Expect(instance.Spec.AWS.NameOrID).Should(Equal("mock-db-instance-7"))
+								Expect(instance.Spec.AWS.ARN).ShouldNot(BeNil())
+								Expect(string(*instance.Spec.AWS.ARN)).Should(Equal("mock-db-instance-7"))
 							}
 							if _, ok := dbInstancesMap["mock-db-instance-5"]; ok {
 								return false
@@ -951,6 +1055,40 @@ var _ = Describe("RDSInventoryController", func() {
 							return err == nil
 						}, timeout).Should(BeTrue())
 
+						assertResourceCreation(mockDBInstance7)()
+						Eventually(func() bool {
+							if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(mockDBInstance7), mockDBInstance7); err != nil {
+								return false
+							}
+							arn := ackv1alpha1.AWSResourceName("mock-db-instance-7")
+							ownerAccountID := ackv1alpha1.AWSAccountID("testOwnerId")
+							region := ackv1alpha1.AWSRegion("us-east-1")
+							mockDBInstance7.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{
+								ARN:            &arn,
+								OwnerAccountID: &ownerAccountID,
+								Region:         &region,
+							}
+							err := k8sClient.Status().Update(ctx, mockDBInstance7)
+							return err == nil
+						}, timeout).Should(BeTrue())
+
+						assertResourceCreation(dbInstance15_0)()
+						Eventually(func() bool {
+							if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dbInstance15_0), dbInstance15_0); err != nil {
+								return false
+							}
+							arn := ackv1alpha1.AWSResourceName("mock-adopted-db-instance-15-0")
+							ownerAccountID := ackv1alpha1.AWSAccountID("testOwnerId")
+							region := ackv1alpha1.AWSRegion("us-east-1")
+							dbInstance15_0.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{
+								ARN:            &arn,
+								OwnerAccountID: &ownerAccountID,
+								Region:         &region,
+							}
+							err := k8sClient.Status().Update(ctx, dbInstance15_0)
+							return err == nil
+						}, timeout).Should(BeTrue())
+
 						Eventually(func() bool {
 							clusterDBInstanceList := &rdsv1alpha1.DBInstanceList{}
 							if e := k8sClient.List(ctx, clusterDBInstanceList, client.InNamespace(inventory.Namespace)); e != nil {
@@ -958,7 +1096,7 @@ var _ = Describe("RDSInventoryController", func() {
 							}
 							dbInstanceMap := map[string]rdsv1alpha1.DBInstance{}
 							for _, dbInstance := range clusterDBInstanceList.Items {
-								dbInstanceMap[*dbInstance.Spec.DBInstanceIdentifier] = dbInstance
+								dbInstanceMap[string(*dbInstance.Status.ACKResourceMetadata.ARN)] = dbInstance
 							}
 							if _, ok := dbInstanceMap["mock-db-instance-1"]; !ok {
 								return false
@@ -970,6 +1108,12 @@ var _ = Describe("RDSInventoryController", func() {
 								return false
 							}
 							if _, ok := dbInstanceMap["mock-db-instance-4"]; !ok {
+								return false
+							}
+							if _, ok := dbInstanceMap["mock-db-instance-7"]; !ok {
+								return false
+							}
+							if _, ok := dbInstanceMap["mock-adopted-db-instance-15-0"]; !ok {
 								return false
 							}
 							return true
@@ -990,7 +1134,7 @@ var _ = Describe("RDSInventoryController", func() {
 							if condition == nil || condition.Status != metav1.ConditionTrue || condition.Reason != "SyncOK" {
 								return false
 							}
-							if len(inv.Status.Instances) < 7 {
+							if len(inv.Status.Instances) < 9 {
 								return false
 							}
 							instancesMap := map[string]dbaasv1alpha1.Instance{}
@@ -1031,7 +1175,7 @@ var _ = Describe("RDSInventoryController", func() {
 							if _, ok := instancesMap[*dbInstance14.Spec.DBInstanceIdentifier]; ok {
 								return false
 							}
-							if _, ok := instancesMap[*dbInstance15.Spec.DBInstanceIdentifier]; ok {
+							if _, ok := instancesMap[*dbInstance15.Spec.DBInstanceIdentifier]; !ok {
 								return false
 							}
 							return true


### PR DESCRIPTION
1. Add db engine type to instance identifier, cr name and instance status
2. When importing db instances and sync db instances status, use ARN instead of db instance identifier to identify db instances

Jira: https://issues.redhat.com/browse/DBAAS-773