### PR TITLE
DBAAS-910: fix duplication of adopted db instances

### DIFF
--- a/controllers/rds/test/dbinstance_mock.go
+++ b/controllers/rds/test/dbinstance_mock.go
@@ -77,6 +77,20 @@ var inventoryTestDBInstances = []*rds.DescribeDBInstancesOutput{
 				Engine:               pointer.String("mysql"),
 				DBInstanceArn:        pointer.String("mock-db-instance-7"),
 			},
+			// Already adopted, not adopted
+			{
+				DBInstanceIdentifier: pointer.String("mock-db-instance-8"),
+				DBInstanceStatus:     pointer.String("available"),
+				Engine:               pointer.String("mysql"),
+				DBInstanceArn:        pointer.String("mock-db-instance-8"),
+			},
+			// DB instance exists, not adopted
+			{
+				DBInstanceIdentifier: pointer.String("mock-db-instance-9"),
+				DBInstanceStatus:     pointer.String("available"),
+				Engine:               pointer.String("mysql"),
+				DBInstanceArn:        pointer.String("mock-db-instance-9"),
+			},
 		},
 	},
 	{

--- a/controllers/rdsinventory_controller.go
+++ b/controllers/rdsinventory_controller.go
@@ -460,12 +460,13 @@ func (r *RDSInventoryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				if _, ok := dbInstanceMap[*dbInstance.DBInstanceArn]; ok {
 					continue
 				}
-				adoptingResource = true
-				logger.Info("Adopting DB Instance", "DB Instance Identifier", *dbInstance.DBInstanceIdentifier, "ARN", *dbInstance.DBInstanceArn)
 
-				if _, ok := adoptedDBInstanceMap[*dbInstance.DBInstanceIdentifier]; ok {
+				if _, ok := adoptedDBInstanceMap[*dbInstance.DBInstanceArn]; ok {
 					continue
 				}
+
+				adoptingResource = true
+				logger.Info("Adopting DB Instance", "DB Instance Identifier", *dbInstance.DBInstanceIdentifier, "ARN", *dbInstance.DBInstanceArn)
 
 				adoptedDBInstance := createAdoptedResource(&dbInstance, &inventory)
 				if e := ophandler.SetOwnerAnnotations(&inventory, adoptedDBInstance); e != nil {


### PR DESCRIPTION
RDS DB instances created in AWS are imported multiple times.
Jira: https://issues.redhat.com/browse/DBAAS-910

Used the wrong key to match the imported db instances in the map, so it failed to recognize the db instances that are already imported.

