### PR TITLE
DBAAS-925: make Inventory not ready before RDS controller handles DB instance adoption

### DIFF
--- a/controllers/rdsinventory_controller.go
+++ b/controllers/rdsinventory_controller.go
@@ -425,10 +425,10 @@ func (r *RDSInventoryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				returnError(e, inventoryStatusReasonBackendError, inventoryStatusMessageGetInstancesError)
 				return true, false
 			}
-			adoptedDBInstanceMap := make(map[string]string, len(adoptedResourceList.Items))
+			adoptedDBInstanceMap := make(map[string]ackv1alpha1.AdoptedResource, len(adoptedResourceList.Items))
 			for _, adoptedDBInstance := range adoptedResourceList.Items {
 				if adoptedDBInstance.Spec.AWS != nil && adoptedDBInstance.Spec.AWS.ARN != nil {
-					adoptedDBInstanceMap[string(*adoptedDBInstance.Spec.AWS.ARN)] = adoptedDBInstance.Spec.AWS.NameOrID
+					adoptedDBInstanceMap[string(*adoptedDBInstance.Spec.AWS.ARN)] = adoptedDBInstance
 				}
 			}
 
@@ -461,7 +461,24 @@ func (r *RDSInventoryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 					continue
 				}
 
-				if _, ok := adoptedDBInstanceMap[*dbInstance.DBInstanceArn]; ok {
+				if adoptedDBInstance, ok := adoptedDBInstanceMap[*dbInstance.DBInstanceArn]; ok {
+					// Wait for the DB instances that are being adopted
+					if adoptedDBInstance.Status.Conditions == nil {
+						adoptingResource = true
+					} else {
+						adopted := false
+						for j := range adoptedDBInstance.Status.Conditions {
+							condition := adoptedDBInstance.Status.Conditions[j]
+							if condition != nil && condition.Type == ackv1alpha1.ConditionTypeAdopted &&
+								condition.Status == v1.ConditionTrue {
+								adopted = true
+								break
+							}
+						}
+						if !adopted {
+							adoptingResource = true
+						}
+					}
 					continue
 				}
 
@@ -628,42 +645,6 @@ func (r *RDSInventoryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			}
 			instances = append(instances, instance)
 		}
-
-		// DB instances found in AWS but not found with RDS controller, check if adopting DB instance is in process
-		if len(awsDBInstanceIdentifiers) > 0 && len(instances) == 0 {
-			adoptedResourceList := &ackv1alpha1.AdoptedResourceList{}
-			if e := r.List(ctx, adoptedResourceList, client.InNamespace(inventory.Namespace)); e != nil {
-				logger.Error(e, "Failed to read adopted DB Instances of the Inventory in the cluster")
-				returnError(e, inventoryStatusReasonBackendError, inventoryStatusMessageGetInstancesError)
-				return true
-			}
-			for i := range adoptedResourceList.Items {
-				adoptedDBInstance := adoptedResourceList.Items[i]
-				if adoptedDBInstance.Spec.AWS == nil || adoptedDBInstance.Spec.AWS.ARN == nil {
-					continue
-				}
-				if _, ok := awsDBInstanceIdentifiers[string(*adoptedDBInstance.Spec.AWS.ARN)]; ok {
-					wait := true
-					// Ignore the DB instances that are already adopted
-					if adoptedDBInstance.Status.Conditions != nil {
-						for j := range adoptedDBInstance.Status.Conditions {
-							condition := adoptedDBInstance.Status.Conditions[j]
-							if condition != nil && condition.Type == ackv1alpha1.ConditionTypeAdopted &&
-								condition.Status == v1.ConditionTrue {
-								wait = false
-								break
-							}
-						}
-					}
-					if wait {
-						logger.Info("Wait for the RDS controller to adopt DB instances")
-						returnRequeueSyncReset()
-						return true
-					}
-				}
-			}
-		}
-
 		inventory.Status.Instances = instances
 
 		if e := r.Status().Update(ctx, &inventory); e != nil {

--- a/controllers/rdsinventory_controller_test.go
+++ b/controllers/rdsinventory_controller_test.go
@@ -1058,6 +1058,23 @@ var _ = Describe("RDSInventoryController", func() {
 							if _, ok := dbInstancesMap["mock-db-custom-4"]; ok {
 								return false
 							}
+
+							By("making DB instances adopted")
+							for i := range adoptedDBInstances.Items {
+								instance := adoptedDBInstances.Items[i]
+								if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&instance), &instance); err != nil {
+									return false
+								}
+								instance.Status.Conditions = []*ackv1alpha1.Condition{
+									{
+										Type:   ackv1alpha1.ConditionTypeAdopted,
+										Status: v1.ConditionTrue,
+									},
+								}
+								if err := k8sClient.Status().Update(ctx, &instance); err != nil {
+									return false
+								}
+							}
 							return true
 						}, timeout).Should(BeTrue())
 


### PR DESCRIPTION
Make Inventory not ready before RDS controller handles DB instance adoption, so that UI will not show the error message of not finding DB instances when creating Inventory.

Jira: https://issues.redhat.com/browse/DBAAS-925